### PR TITLE
fix: re-check llama.cpp loaded model periodically instead of once per process

### DIFF
--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -48,9 +48,12 @@ function normalizeV1(baseURL: string): string {
 }
 
 // llama-server (or llama-swap in front of it) exposes GET /v1/models.
-// Cache discovery per base URL — the loaded model doesn't change mid-session,
-// and we don't want a discovery round-trip on every agent step.
-const discoveryCache = new Map<string, Promise<string>>();
+// Cache discovery per base URL for a short TTL — avoids a discovery
+// round-trip on every single agent turn, while still noticing within a
+// session that the user swapped which model llama-swap has loaded (a
+// process-lifetime cache would never see that again without a restart).
+const DISCOVERY_TTL_MS = 60_000;
+const discoveryCache = new Map<string, { promise: Promise<string>; expiresAt: number }>();
 
 /**
  * Pick a model id from llama-server's /v1/models. Prefers a model llama-swap
@@ -59,28 +62,29 @@ const discoveryCache = new Map<string, Promise<string>>();
  */
 export async function discoverLlamaCppModel(baseURL: string): Promise<string> {
   const url = normalizeV1(baseURL);
-  let cached = discoveryCache.get(url);
-  if (!cached) {
-    cached = (async () => {
-      const res = await fetch(`${url}/models`);
-      if (!res.ok) {
-        throw new Error(`llama-server model discovery failed: ${res.status} at ${url}/models`);
-      }
-      const body = (await res.json()) as {
-        data?: { id: string; status?: { value?: string } }[];
-      };
-      const models = body.data ?? [];
-      if (models.length === 0) {
-        throw new Error(`llama-server at ${url} lists no models`);
-      }
-      const loaded = models.find((m) => m.status?.value === "loaded");
-      return (loaded ?? models[0]).id;
-    })();
-    discoveryCache.set(url, cached);
-    // Don't cache failures — the server may just be starting up.
-    cached.catch(() => discoveryCache.delete(url));
+  const cached = discoveryCache.get(url);
+  if (cached && cached.expiresAt > Date.now()) {
+    return cached.promise;
   }
-  return cached;
+  const promise = (async () => {
+    const res = await fetch(`${url}/models`);
+    if (!res.ok) {
+      throw new Error(`llama-server model discovery failed: ${res.status} at ${url}/models`);
+    }
+    const body = (await res.json()) as {
+      data?: { id: string; status?: { value?: string } }[];
+    };
+    const models = body.data ?? [];
+    if (models.length === 0) {
+      throw new Error(`llama-server at ${url} lists no models`);
+    }
+    const loaded = models.find((m) => m.status?.value === "loaded");
+    return (loaded ?? models[0]).id;
+  })();
+  discoveryCache.set(url, { promise, expiresAt: Date.now() + DISCOVERY_TTL_MS });
+  // Don't cache failures — the server may just be starting up.
+  promise.catch(() => discoveryCache.delete(url));
+  return promise;
 }
 
 export async function resolveModel(

--- a/packages/core/test/providers.test.ts
+++ b/packages/core/test/providers.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { discoverLlamaCppModel } from "../src/providers/index.js";
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), { status: 200 });
+}
+
+// Each test uses its own base URL — discovery is cached per URL, and the
+// cache is module-level state shared across tests in this file.
+let counter = 0;
+function freshBaseURL() {
+  return `http://localhost:${8080 + counter++}`;
+}
+
+describe("discoverLlamaCppModel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("fetch", vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("prefers the model llama-swap reports as loaded", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      jsonResponse({
+        data: [
+          { id: "model-a", status: { value: "unloaded" } },
+          { id: "model-b", status: { value: "loaded" } },
+        ],
+      })
+    );
+    await expect(discoverLlamaCppModel(freshBaseURL())).resolves.toBe("model-b");
+  });
+
+  it("does not re-fetch within the TTL window", async () => {
+    const url = freshBaseURL();
+    vi.mocked(fetch).mockResolvedValue(jsonResponse({ data: [{ id: "model-a" }] }));
+    await discoverLlamaCppModel(url);
+    await discoverLlamaCppModel(url);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-checks the loaded model again after the TTL expires", async () => {
+    const url = freshBaseURL();
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "model-a" }] }))
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "model-b" }] }));
+
+    await expect(discoverLlamaCppModel(url)).resolves.toBe("model-a");
+    vi.advanceTimersByTime(61_000);
+    await expect(discoverLlamaCppModel(url)).resolves.toBe("model-b");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not cache a failed discovery", async () => {
+    const url = freshBaseURL();
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(new Response("boom", { status: 500 }))
+      .mockResolvedValueOnce(jsonResponse({ data: [{ id: "model-a" }] }));
+
+    await expect(discoverLlamaCppModel(url)).rejects.toThrow();
+    await expect(discoverLlamaCppModel(url)).resolves.toBe("model-a");
+    expect(fetch).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary
- `discoverLlamaCppModel` cached the model returned by `GET /v1/models` in a `Map` that lived for the entire process — with a long-running server (e.g. the Docker/HTTP deployment), the loaded model was effectively only ever checked once, no matter how many times the model behind `llama-swap` changed.
- The cache now expires after 60s, so a model swap is picked up again well within a session, without adding a discovery round-trip to every single request.

## Test plan
- [x] `pnpm --filter @understory/core test` — added `packages/core/test/providers.test.ts` covering: prefers the `loaded` model, doesn't re-fetch within the TTL window, re-checks after the TTL expires, and doesn't cache a failed discovery.
- [x] `pnpm --filter @understory/core build` — typechecks cleanly.