### PR TITLE
Generalize providers: two configurable slots + model-level fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,24 +1,31 @@
 # Path to the OKF bundle directory the agent manages
 BUNDLE_ROOT=./sample-bundle
 
-# LLM provider: anthropic | openrouter | llamacpp | local
-LLM_PROVIDER=anthropic
-# Optional model override (defaults: claude-sonnet-5 / anthropic/claude-sonnet-5 /
-# auto-discovered from llama-server / local-model)
-#LLM_MODEL=
+# ── Primary model ──────────────────────────────────────────────────────
+# Any OpenAI-compatible or Anthropic-compatible API endpoint.
+LLM_API_BASE_URL=
+LLM_API_KEY=
+LLM_API_FORMAT=openai          # "openai" | "anthropic"
+LLM_MODEL=                     # model id to request, e.g. "deepseek-chat" or "claude-sonnet-5"
 
-ANTHROPIC_API_KEY=
-#OPENROUTER_API_KEY=
+# ── Fallback model (optional) ──────────────────────────────────────────
+# Used when the primary model fails with a retryable error (timeout, 5xx).
+# Leave LLM_FALLBACK_API_BASE_URL empty to disable fallback.
+LLM_FALLBACK_API_BASE_URL=
+LLM_FALLBACK_API_KEY=
+LLM_FALLBACK_API_FORMAT=openai
+LLM_FALLBACK_MODEL=
+# LLM_FALLBACK_ALLOW_FOR=query   # optional: restrict to read-only operations
 
-# llama.cpp llama-server (or llama-swap). /v1 appended automatically.
-# Model is auto-discovered from /v1/models (prefers the loaded model under llama-swap);
-# set LLM_MODEL to pin one. Start llama-server with --jinja for tool calling.
-#LLAMACPP_BASE_URL=http://localhost:8080
-#LLAMACPP_API_KEY=            # only if llama-server was started with --api-key
-
-# Any other OpenAI-compatible server:
-#LOCAL_BASE_URL=http://localhost:8080/v1
-#LOCAL_API_KEY=
+# ── Legacy env vars (still work but deprecated) ─────────────────────────
+# Prefer the LLM_API_* vars above. These are mapped automatically.
+# ANTHROPIC_API_KEY=
+# OPENROUTER_API_KEY=
+# DEEPSEEK_API_KEY=
+# LLAMACPP_BASE_URL=
+# LLAMACPP_API_KEY=
+# LOCAL_BASE_URL=
+# LOCAL_API_KEY=
 
 # Commit bundle changes to git after each mutation
 GIT_AUTOCOMMIT=false

--- a/README.md
+++ b/README.md
@@ -31,16 +31,15 @@ services:
       - understory-memory:/bundle
     environment:
       BUNDLE_ROOT: /bundle
-      # Pick ONE provider:
-      # 1) Local llama.cpp / llama-swap (model auto-discovered; start llama-server with --jinja)
-      LLM_PROVIDER: llamacpp
-      LLAMACPP_BASE_URL: http://your-inference-box:8080
-      # 2) Anthropic
-      #LLM_PROVIDER: anthropic
-      #ANTHROPIC_API_KEY: sk-ant-...
-      # 3) OpenRouter
-      #LLM_PROVIDER: openrouter
-      #OPENROUTER_API_KEY: sk-or-...
+      LLM_API_BASE_URL: ${LLM_API_BASE_URL}
+      LLM_API_KEY: ${LLM_API_KEY}
+      LLM_API_FORMAT: openai
+      LLM_MODEL: ${LLM_MODEL:-}
+      # Optional fallback
+      LLM_FALLBACK_API_BASE_URL: ${LLM_FALLBACK_API_BASE_URL:-}
+      LLM_FALLBACK_API_KEY: ${LLM_FALLBACK_API_KEY:-}
+      LLM_FALLBACK_API_FORMAT: ${LLM_FALLBACK_API_FORMAT:-openai}
+      LLM_FALLBACK_MODEL: ${LLM_FALLBACK_MODEL:-}
     restart: unless-stopped
 
 volumes:
@@ -50,6 +49,44 @@ volumes:
 ```bash
 docker compose up -d
 ```
+
+### Choosing a provider
+
+The generic provider system supports any OpenAI-compatible or Anthropic-compatible API.
+Set `LLM_API_BASE_URL` + `LLM_API_KEY` + `LLM_MODEL` and leave `LLM_PROVIDER` unset.
+
+**DeepSeek:**
+```bash
+LLM_API_BASE_URL=https://api.deepseek.com/v1 LLM_API_KEY=sk-... LLM_MODEL=deepseek-chat
+```
+
+**OpenAI:**
+```bash
+LLM_API_BASE_URL=https://api.openai.com/v1 LLM_API_KEY=sk-... LLM_MODEL=gpt-4o
+```
+
+**Anthropic (Claude):**
+```bash
+LLM_API_BASE_URL=https://api.anthropic.com/v1 LLM_API_KEY=sk-ant-... LLM_API_FORMAT=anthropic LLM_MODEL=claude-sonnet-5
+```
+
+**Groq:**
+```bash
+LLM_API_BASE_URL=https://api.groq.com/openai/v1 LLM_API_KEY=gsk_... LLM_MODEL=llama-3.3-70b-versatile
+```
+
+**Local llama.cpp:**
+```bash
+LLM_API_BASE_URL=http://localhost:8080/v1 LLM_MODEL=
+```
+
+**Local llama.cpp with DeepSeek fallback:**
+```bash
+LLM_API_BASE_URL=http://localhost:8080/v1 LLM_MODEL= \
+LLM_FALLBACK_API_BASE_URL=https://api.deepseek.com/v1 LLM_FALLBACK_API_KEY=sk-... LLM_FALLBACK_MODEL=deepseek-chat
+```
+
+The old `LLM_PROVIDER` + per-provider key env vars still work (backward-compatible) but are deprecated.
 
 Then:
 
@@ -72,7 +109,7 @@ pnpm monorepo:
 | `packages/server` | Express: MCP streamable-HTTP at `/mcp`, stdio bin, REST browse API at `/api/*`, streaming chat at `/api/chat`, serves the web build |
 | `packages/web` | Vite + React + TS + Tailwind: bundle browser + agent chat (`useChat`) |
 
-Providers (env-selected, swappable per chat): **Anthropic** (default), **OpenRouter**, **llamacpp** (llama.cpp `llama-server` / llama-swap — model auto-discovered from `/v1/models`, loaded model preferred), **local** (any other OpenAI-compatible endpoint).
+Providers are configured through `LLM_API_BASE_URL`, `LLM_API_KEY`, `LLM_API_FORMAT` (`openai` or `anthropic`), and `LLM_MODEL`. Any OpenAI-compatible endpoint (DeepSeek, OpenAI, Groq, OpenRouter, llama.cpp, etc.) works with `LLM_API_FORMAT=openai`; Anthropic-compatible endpoints use `LLM_API_FORMAT=anthropic`. Optional fallback uses the matching `LLM_FALLBACK_*` variables.
 
 ### llama.cpp
 
@@ -80,8 +117,8 @@ Providers (env-selected, swappable per chat): **Anthropic** (default), **OpenRou
 # on the inference box — --jinja enables OpenAI-style tool calling
 llama-server -m model.gguf --jinja --host 0.0.0.0 --port 8080
 
-# here — no model id needed, it's discovered
-LLM_PROVIDER=llamacpp LLAMACPP_BASE_URL=http://inference-box:8080 \
+# here — no model id needed, it's discovered for llama-server-like local endpoints
+LLM_API_BASE_URL=http://inference-box:8080/v1 LLM_API_FORMAT=openai LLM_MODEL= \
 BUNDLE_ROOT=./sample-bundle node packages/server/dist/index.js
 ```
 
@@ -94,7 +131,12 @@ pnpm install
 pnpm build
 cp .env.example .env   # add your API key
 
-BUNDLE_ROOT=./sample-bundle ANTHROPIC_API_KEY=sk-... node packages/server/dist/index.js
+BUNDLE_ROOT=./sample-bundle \
+LLM_API_BASE_URL=https://api.deepseek.com/v1 \
+LLM_API_KEY=sk-... \
+LLM_API_FORMAT=openai \
+LLM_MODEL=deepseek-chat \
+node packages/server/dist/index.js
 # → http://localhost:3800  (web UI + /api + /mcp)
 ```
 
@@ -112,7 +154,10 @@ pnpm --filter @understory/web dev
 ```bash
 claude mcp add ustory \
   -e BUNDLE_ROOT=/path/to/your/bundle \
-  -e ANTHROPIC_API_KEY=sk-... \
+  -e LLM_API_BASE_URL=https://api.deepseek.com/v1 \
+  -e LLM_API_KEY=sk-... \
+  -e LLM_API_FORMAT=openai \
+  -e LLM_MODEL=deepseek-chat \
   -- node /path/to/understory/packages/server/dist/mcp/stdio.js
 ```
 

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -13,15 +13,25 @@ services:
     environment:
       BUNDLE_ROOT: /bundle
       AUTH_TOKEN: ${AUTH_TOKEN:-}
-      # anthropic | openrouter | llamacpp | local
-      LLM_PROVIDER: ${LLM_PROVIDER:-llamacpp}
+      # Primary model
+      LLM_API_BASE_URL: ${LLM_API_BASE_URL}
+      LLM_API_KEY: ${LLM_API_KEY}
+      LLM_API_FORMAT: ${LLM_API_FORMAT:-openai}
       LLM_MODEL: ${LLM_MODEL:-}
+      # Fallback model
+      LLM_FALLBACK_API_BASE_URL: ${LLM_FALLBACK_API_BASE_URL:-}
+      LLM_FALLBACK_API_KEY: ${LLM_FALLBACK_API_KEY:-}
+      LLM_FALLBACK_API_FORMAT: ${LLM_FALLBACK_API_FORMAT:-openai}
+      LLM_FALLBACK_MODEL: ${LLM_FALLBACK_MODEL:-}
+      LLM_FALLBACK_ALLOW_FOR: ${LLM_FALLBACK_ALLOW_FOR:-query}
+      # Legacy compat (still supported)
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
-      # Homelab llama-server / llama-swap (model auto-discovered):
-      LLAMACPP_BASE_URL: ${LLAMACPP_BASE_URL:-http://192.168.1.101:8080}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
+      LLAMACPP_BASE_URL: ${LLAMACPP_BASE_URL:-}
       LLAMACPP_API_KEY: ${LLAMACPP_API_KEY:-}
       LOCAL_BASE_URL: ${LOCAL_BASE_URL:-}
+      LOCAL_API_KEY: ${LOCAL_API_KEY:-}
       GIT_AUTOCOMMIT: ${GIT_AUTOCOMMIT:-false}
     restart: unless-stopped
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   understory:
-    image: ghcr.io/thecodacus/understory:latest
+    build: .
     ports:
       - "3800:3800"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   understory:
-    build: .
+    image: ghcr.io/thecodacus/understory:latest
     ports:
       - "3800:3800"
     volumes:
@@ -8,12 +8,24 @@ services:
     environment:
       BUNDLE_ROOT: /bundle
       AUTH_TOKEN: ${AUTH_TOKEN:-}
-      LLM_PROVIDER: ${LLM_PROVIDER:-anthropic}
+      # Primary model
+      LLM_API_BASE_URL: ${LLM_API_BASE_URL}
+      LLM_API_KEY: ${LLM_API_KEY}
+      LLM_API_FORMAT: ${LLM_API_FORMAT:-openai}
       LLM_MODEL: ${LLM_MODEL:-}
+      # Fallback model
+      LLM_FALLBACK_API_BASE_URL: ${LLM_FALLBACK_API_BASE_URL:-}
+      LLM_FALLBACK_API_KEY: ${LLM_FALLBACK_API_KEY:-}
+      LLM_FALLBACK_API_FORMAT: ${LLM_FALLBACK_API_FORMAT:-openai}
+      LLM_FALLBACK_MODEL: ${LLM_FALLBACK_MODEL:-}
+      LLM_FALLBACK_ALLOW_FOR: ${LLM_FALLBACK_ALLOW_FOR:-query}
+      # Legacy compat (still supported)
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      DEEPSEEK_API_KEY: ${DEEPSEEK_API_KEY:-}
       LLAMACPP_BASE_URL: ${LLAMACPP_BASE_URL:-}
       LLAMACPP_API_KEY: ${LLAMACPP_API_KEY:-}
       LOCAL_BASE_URL: ${LOCAL_BASE_URL:-}
+      LOCAL_API_KEY: ${LOCAL_API_KEY:-}
       GIT_AUTOCOMMIT: ${GIT_AUTOCOMMIT:-false}
     restart: unless-stopped

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^2.0.0",
     "@ai-sdk/openai-compatible": "^1.0.0",
-    "@openrouter/ai-sdk-provider": "^1.0.0",
     "ai": "^5.0.0",
     "gray-matter": "^4.0.3",
     "simple-git": "^3.27.0",

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -65,7 +65,9 @@ async function resolveAgentModel(
 
   const fallback = await createModel(fallbackConfig);
   return {
-    model: withFallback(primary, fallback),
+    model: withFallback(primary, fallback, {
+      retry429: env.LLM_FALLBACK_RETRY_429 === "true",
+    }),
     modelChain: [modelLabel(primaryConfig), modelLabel(fallbackConfig)],
   };
 }
@@ -79,8 +81,10 @@ function withModelOverride(config: ModelConfig, model: string | undefined): Mode
   return model ? { ...config, model } : config;
 }
 
+// No baseURL here by design: traces persist under <bundle>/.traces/, and a
+// published bundle would otherwise leak internal hostnames/IPs/ports.
 function modelLabel(config: ModelConfig): string {
-  return `${config.format}:${config.model || "auto"}@${config.baseURL}`;
+  return `${config.format}:${config.model || "auto"}`;
 }
 
 function traceStore(kb: KnowledgeBase): TraceStore {

--- a/packages/core/src/agent/agent.ts
+++ b/packages/core/src/agent/agent.ts
@@ -1,6 +1,12 @@
 import { generateText, streamText, stepCountIs, type LanguageModel, type ModelMessage } from "ai";
 import type { KnowledgeBase } from "../okf/index.js";
-import { resolveModel, type ProviderName } from "../providers/index.js";
+import {
+  createModel,
+  resolveFallbackConfig,
+  resolveModelConfig,
+  type ModelConfig,
+} from "../providers/index.js";
+import { withFallback } from "../providers/fallback.js";
 import { buildSystemPrompt } from "./system-prompt.js";
 import { buildReadTools, buildWriteTools, formatTree } from "./tools.js";
 import { TraceRecorder, TraceStore } from "./trace.js";
@@ -8,7 +14,6 @@ import { TraceRecorder, TraceStore } from "./trace.js";
 const MAX_STEPS = 12;
 
 export interface AgentOptions {
-  provider?: ProviderName;
   model?: string;
 }
 
@@ -25,17 +30,65 @@ export interface MutationResult {
   traceId: string;
 }
 
+export type MutationOutcome =
+  | { ok: true; result: MutationResult }
+  | { ok: false; status: "partial"; filesChanged: string[]; error: string; traceId: string }
+  | { ok: false; status: "failed"; error: string };
+
+interface ResolvedAgentModel {
+  model: LanguageModel;
+  modelChain: string[];
+}
+
 async function promptContext(kb: KnowledgeBase, mode: "query" | "mutate" | "chat") {
   const [types, tree] = await Promise.all([kb.listTypes(), kb.listTree()]);
   return { existingTypes: types, treeSummary: formatTree(tree), mode };
 }
 
-function pickModel(options: AgentOptions): Promise<LanguageModel> {
-  return resolveModel(options.provider, options.model);
+async function resolveAgentModel(
+  options: AgentOptions,
+  mode: "query" | "mutate" | "chat",
+  env: NodeJS.ProcessEnv = process.env
+): Promise<ResolvedAgentModel> {
+  const primaryConfig = withModelOverride(resolveModelConfig(env), options.model);
+  const primary = await createModel(primaryConfig);
+  const fallbackConfig = resolveFallbackConfig(env);
+
+  if (!fallbackConfig) {
+    return { model: primary, modelChain: [modelLabel(primaryConfig)] };
+  }
+
+  const allowFor = resolveAllowFor(env.LLM_FALLBACK_ALLOW_FOR);
+  if (allowFor && !allowFor.has(mode)) {
+    return { model: primary, modelChain: [modelLabel(primaryConfig)] };
+  }
+
+  const fallback = await createModel(fallbackConfig);
+  return {
+    model: withFallback(primary, fallback),
+    modelChain: [modelLabel(primaryConfig), modelLabel(fallbackConfig)],
+  };
+}
+
+function resolveAllowFor(raw: string | undefined): Set<string> | null {
+  if (!raw || raw === "*") return null;
+  return new Set(raw.split(",").map((s) => s.trim()).filter(Boolean));
+}
+
+function withModelOverride(config: ModelConfig, model: string | undefined): ModelConfig {
+  return model ? { ...config, model } : config;
+}
+
+function modelLabel(config: ModelConfig): string {
+  return `${config.format}:${config.model || "auto"}@${config.baseURL}`;
 }
 
 function traceStore(kb: KnowledgeBase): TraceStore {
   return new TraceStore(kb.bundle.root);
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
 }
 
 /** Read-only Q&A over the bundle. */
@@ -46,16 +99,25 @@ export async function runQuery(
 ): Promise<QueryResult> {
   const ctx = await promptContext(kb, "query");
   const recorder = new TraceRecorder();
-  const result = await generateText({
-    model: await pickModel(options),
-    system: buildSystemPrompt(ctx),
-    prompt: question,
-    tools: buildReadTools(kb, recorder),
-    stopWhen: stepCountIs(MAX_STEPS),
-  });
-  const trace = recorder.finalize("query", question, result.text);
-  await traceStore(kb).save(trace);
-  return { answer: result.text, steps: result.steps.length, traceId: trace.id };
+  let modelChain: string[] = [];
+  try {
+    const resolved = await resolveAgentModel(options, "query");
+    modelChain = resolved.modelChain;
+    const result = await generateText({
+      model: resolved.model,
+      system: buildSystemPrompt(ctx),
+      prompt: question,
+      tools: buildReadTools(kb, recorder),
+      stopWhen: stepCountIs(MAX_STEPS),
+    });
+    const trace = recorder.finalize("query", question, result.text, "success", modelChain);
+    await traceStore(kb).save(trace);
+    return { answer: result.text, steps: result.steps.length, traceId: trace.id };
+  } catch (err) {
+    const trace = recorder.finalize("query", question, errorMessage(err), "failed", modelChain);
+    await traceStore(kb).save(trace);
+    throw err;
+  }
 }
 
 /** Knowledge add/update — full toolset, low temperature. */
@@ -63,26 +125,46 @@ export async function runMutation(
   kb: KnowledgeBase,
   instruction: string,
   options: AgentOptions = {}
-): Promise<MutationResult> {
+): Promise<MutationOutcome> {
   const ctx = await promptContext(kb, "mutate");
   const recorder = new TraceRecorder();
   const filesChanged = new Set<string>();
-  const result = await generateText({
-    model: await pickModel(options),
-    system: buildSystemPrompt(ctx),
-    prompt: instruction,
-    tools: { ...buildReadTools(kb, recorder), ...buildWriteTools(kb, filesChanged, recorder) },
-    stopWhen: stepCountIs(MAX_STEPS),
-    temperature: 0.2,
-  });
-  const trace = recorder.finalize("mutation", instruction, result.text);
-  await traceStore(kb).save(trace);
-  return {
-    summary: result.text,
-    filesChanged: [...filesChanged].sort(),
-    steps: result.steps.length,
-    traceId: trace.id,
-  };
+  let modelChain: string[] = [];
+  try {
+    const resolved = await resolveAgentModel(options, "mutate");
+    modelChain = resolved.modelChain;
+    const result = await generateText({
+      model: resolved.model,
+      system: buildSystemPrompt(ctx),
+      prompt: instruction,
+      tools: { ...buildReadTools(kb, recorder), ...buildWriteTools(kb, filesChanged, recorder) },
+      stopWhen: stepCountIs(MAX_STEPS),
+      temperature: 0.2,
+    });
+    const trace = recorder.finalize("mutation", instruction, result.text, "success", modelChain);
+    await traceStore(kb).save(trace);
+    return {
+      ok: true,
+      result: {
+        summary: result.text,
+        filesChanged: [...filesChanged].sort(),
+        steps: result.steps.length,
+        traceId: trace.id,
+      },
+    };
+  } catch (err) {
+    const files = [...filesChanged].sort();
+    const message = errorMessage(err);
+    if (files.length > 0) {
+      const summary = `Partial mutation: ${files.length} file(s) changed before failure. Error: ${message}`;
+      const trace = recorder.finalize("mutation", instruction, summary, "partial", modelChain);
+      await traceStore(kb).save(trace);
+      return { ok: false, status: "partial", filesChanged: files, error: message, traceId: trace.id };
+    }
+    const trace = recorder.finalize("mutation", instruction, message, "failed", modelChain);
+    await traceStore(kb).save(trace);
+    return { ok: false, status: "failed", error: message };
+  }
 }
 
 /** Interactive chat — full toolset, streaming. Caller converts to a UI stream response. */
@@ -94,6 +176,7 @@ export async function streamChat(
   const ctx = await promptContext(kb, "chat");
   const recorder = new TraceRecorder();
   const filesChanged = new Set<string>();
+  let modelChain: string[] = [];
   // The user turn that started this run, for the trace record.
   const lastUser = [...messages].reverse().find((m) => m.role === "user");
   const input =
@@ -104,18 +187,26 @@ export async function streamChat(
           .join(" ")
           .trim() ?? "(chat)";
 
-  const result = streamText({
-    model: await pickModel(options),
-    system: buildSystemPrompt(ctx),
-    messages,
-    tools: { ...buildReadTools(kb, recorder), ...buildWriteTools(kb, filesChanged, recorder) },
-    stopWhen: stepCountIs(MAX_STEPS),
-    onFinish: async ({ text }) => {
-      // Persist only turns that actually touched the bundle.
-      if (recorder.steps.length > 0) {
-        await traceStore(kb).save(recorder.finalize("chat", input, text));
-      }
-    },
-  });
-  return { result, filesChanged };
+  try {
+    const resolved = await resolveAgentModel(options, "chat");
+    modelChain = resolved.modelChain;
+    const result = streamText({
+      model: resolved.model,
+      system: buildSystemPrompt(ctx),
+      messages,
+      tools: { ...buildReadTools(kb, recorder), ...buildWriteTools(kb, filesChanged, recorder) },
+      stopWhen: stepCountIs(MAX_STEPS),
+      onFinish: async ({ text }) => {
+        // Persist only turns that actually touched the bundle.
+        if (recorder.steps.length > 0) {
+          await traceStore(kb).save(recorder.finalize("chat", input, text, "success", modelChain));
+        }
+      },
+    });
+    return { result, filesChanged };
+  } catch (err) {
+    const outcome = filesChanged.size > 0 ? "partial" : "failed";
+    await traceStore(kb).save(recorder.finalize("chat", input, errorMessage(err), outcome, modelChain));
+    throw err;
+  }
 }

--- a/packages/core/src/agent/cli.ts
+++ b/packages/core/src/agent/cli.ts
@@ -25,7 +25,14 @@ if (mode === "query") {
   console.log(answer);
   console.error(`\n[${steps} steps]`);
 } else {
-  const { summary, filesChanged, steps } = await runMutation(kb, input);
-  console.log(summary);
-  console.error(`\n[${steps} steps] files changed: ${filesChanged.join(", ") || "none"}`);
+  const outcome = await runMutation(kb, input);
+  if (outcome.ok) {
+    console.log(outcome.result.summary);
+    console.error(
+      `\n[${outcome.result.steps} steps] files changed: ${outcome.result.filesChanged.join(", ") || "none"}`
+    );
+  } else {
+    console.error(`Mutation failed: ${outcome.error}`);
+    process.exit(1);
+  }
 }

--- a/packages/core/src/agent/index.ts
+++ b/packages/core/src/agent/index.ts
@@ -1,6 +1,6 @@
 export { runQuery, runMutation, streamChat } from "./agent.js";
-export type { AgentOptions, QueryResult, MutationResult } from "./agent.js";
+export type { AgentOptions, QueryResult, MutationResult, MutationOutcome } from "./agent.js";
 export { buildSystemPrompt } from "./system-prompt.js";
 export { buildReadTools, buildWriteTools, formatTree } from "./tools.js";
 export { TraceRecorder, TraceStore, buildNotation } from "./trace.js";
-export type { QueryTrace, TraceStep } from "./trace.js";
+export type { QueryTrace, TraceStep, TraceOutcome } from "./trace.js";

--- a/packages/core/src/agent/trace.ts
+++ b/packages/core/src/agent/trace.ts
@@ -13,6 +13,8 @@ export interface TraceStep {
   write?: boolean;
 }
 
+export type TraceOutcome = "success" | "partial" | "failed";
+
 export interface QueryTrace {
   id: string;
   kind: "query" | "mutation" | "chat";
@@ -25,6 +27,8 @@ export interface QueryTrace {
   answer: string;
   /** Compact one-line notation of the traversal. */
   notation: string;
+  outcome: TraceOutcome;
+  modelChain: string[];
 }
 
 /** Collects steps during one agent run. Thread one instance through the tools. */
@@ -36,7 +40,13 @@ export class TraceRecorder {
     this.steps.push({ seq: this.steps.length + 1, tool, summary, paths, write });
   }
 
-  finalize(kind: QueryTrace["kind"], input: string, answer: string): QueryTrace {
+  finalize(
+    kind: QueryTrace["kind"],
+    input: string,
+    answer: string,
+    outcome: TraceOutcome = "success",
+    modelChain: string[] = []
+  ): QueryTrace {
     return {
       id: `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 7)}`,
       kind,
@@ -45,14 +55,19 @@ export class TraceRecorder {
       durationMs: Date.now() - this.t0,
       steps: this.steps,
       answer: truncate(answer, 500),
-      notation: buildNotation(this.steps),
+      notation: buildNotation(this.steps, outcome),
+      outcome,
+      modelChain,
     };
   }
 }
 
 /** Compact single-line traversal notation, e.g.
  *  `search "rate limit" (2) → read /apis/billing-api.md → ✓` */
-export function buildNotation(steps: TraceStep[]): string {
+export function buildNotation(
+  steps: TraceStep[],
+  outcome: TraceOutcome = "success"
+): string {
   const parts = steps.map((s) => {
     switch (s.tool) {
       case "search_knowledge":
@@ -73,7 +88,18 @@ export function buildNotation(steps: TraceStep[]): string {
         return s.tool;
     }
   });
-  return [...parts, "✓"].join(" → ");
+  return [...parts, outcomeMarker(outcome)].join(" → ");
+}
+
+function outcomeMarker(outcome: TraceOutcome): string {
+  switch (outcome) {
+    case "success":
+      return "✓";
+    case "partial":
+      return "⚠ partial";
+    case "failed":
+      return "✗";
+  }
 }
 
 function shortPath(p: string): string {

--- a/packages/core/src/providers/fallback.ts
+++ b/packages/core/src/providers/fallback.ts
@@ -61,13 +61,15 @@ export function isRetryableError(err: unknown): boolean {
   if (typeof err === "number") return isRetryableStatusCode(err);
   if (isAbortError(err)) return false;
 
+  // AI SDK wraps transport failures in RetryError with isRetryable: true.
+  if (getIsRetryable(err)) return true;
+
   const statusCode = getStatusCode(err);
   if (statusCode != null) return isRetryableStatusCode(statusCode);
 
-  const code = getErrorCode(err);
-  if (code && ["ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "ENOTFOUND"].includes(code)) {
-    return true;
-  }
+  // Walk the error and its cause chain for transport codes.
+  const code = getDeepErrorCode(err);
+  if (code && isTransportCode(code)) return true;
 
   // Node/undici fetch failures commonly surface as TypeError.
   if (err instanceof TypeError) return true;
@@ -93,6 +95,31 @@ function getErrorCode(err: unknown): string | undefined {
   if (!err || typeof err !== "object") return undefined;
   const value = (err as { code?: unknown }).code;
   return typeof value === "string" ? value : undefined;
+}
+
+function getIsRetryable(err: unknown): boolean {
+  if (!err || typeof err !== "object") return false;
+  return (err as { isRetryable?: unknown }).isRetryable === true;
+}
+
+/** Walk the error and its cause chain for the first transport-level code. */
+function getDeepErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const code = getErrorCode(err);
+  if (code) return code;
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause && typeof cause === "object") return getDeepErrorCode(cause);
+  return undefined;
+}
+
+/** Undici/Node transport error codes. */
+function isTransportCode(code: string): boolean {
+  const codes = [
+    "ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "ENOTFOUND",
+    "UND_ERR_CONNECT_TIMEOUT", "UND_ERR_HEADERS_TIMEOUT",
+    "UND_ERR_SOCKET",
+  ];
+  return codes.includes(code);
 }
 
 function isAbortError(err: unknown): boolean {

--- a/packages/core/src/providers/fallback.ts
+++ b/packages/core/src/providers/fallback.ts
@@ -1,0 +1,111 @@
+import type { LanguageModel } from "ai";
+
+type ResolvedLanguageModel = Extract<LanguageModel, { doGenerate: unknown }>;
+
+export interface FallbackOptions {
+  maxInputTokens?: number;
+  allowFor?: ("query" | "mutate" | "chat")[];
+}
+
+/**
+ * Wraps a primary LanguageModel with a fallback. If primary.doGenerate or
+ * primary.doStream (setup phase) fails with a retryable error, the fallback
+ * is tried instead for that one generation step. Mid-stream failures are NOT
+ * retried — they propagate as stream errors.
+ */
+export function withFallback(
+  primary: LanguageModel,
+  fallback: LanguageModel,
+  _opts: FallbackOptions = {}
+): LanguageModel {
+  const primaryModel = primary as ResolvedLanguageModel;
+  const fallbackModel = fallback as ResolvedLanguageModel;
+  return {
+    ...primaryModel,
+    async doGenerate(options) {
+      try {
+        return await primaryModel.doGenerate(options);
+      } catch (err) {
+        if (!isRetryableError(err)) throw err;
+        try {
+          return await fallbackModel.doGenerate(options);
+        } catch (fallbackErr) {
+          throw combinedFallbackError(err, fallbackErr);
+        }
+      }
+    },
+    async doStream(options) {
+      try {
+        return await primaryModel.doStream(options);
+      } catch (err) {
+        // This only catches stream setup failures. Once a stream has been
+        // returned to the caller, later stream errors must propagate; they
+        // cannot be transparently failed over without replaying emitted events.
+        if (!isRetryableError(err)) throw err;
+        try {
+          return await fallbackModel.doStream(options);
+        } catch (fallbackErr) {
+          throw combinedFallbackError(err, fallbackErr);
+        }
+      }
+    },
+  } as LanguageModel;
+}
+
+/**
+ * Positive allowlist: retry only on recognized transport/provider failures.
+ * 401/403/AbortError are NOT retryable. 429 retries are opt-in via
+ * LLM_FALLBACK_RETRY_429=true.
+ */
+export function isRetryableError(err: unknown): boolean {
+  if (typeof err === "number") return isRetryableStatusCode(err);
+  if (isAbortError(err)) return false;
+
+  const statusCode = getStatusCode(err);
+  if (statusCode != null) return isRetryableStatusCode(statusCode);
+
+  const code = getErrorCode(err);
+  if (code && ["ECONNRESET", "ECONNREFUSED", "ETIMEDOUT", "ENOTFOUND"].includes(code)) {
+    return true;
+  }
+
+  // Node/undici fetch failures commonly surface as TypeError.
+  if (err instanceof TypeError) return true;
+
+  return false;
+}
+
+function isRetryableStatusCode(statusCode: number): boolean {
+  if (statusCode === 401 || statusCode === 403) return false;
+  if (statusCode === 429) return process.env.LLM_FALLBACK_RETRY_429 === "true";
+  return statusCode === 408 || (statusCode >= 500 && statusCode < 600);
+}
+
+function getStatusCode(err: unknown): number | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const value =
+    (err as { statusCode?: unknown; status?: unknown }).statusCode ??
+    (err as { status?: unknown }).status;
+  return typeof value === "number" ? value : undefined;
+}
+
+function getErrorCode(err: unknown): string | undefined {
+  if (!err || typeof err !== "object") return undefined;
+  const value = (err as { code?: unknown }).code;
+  return typeof value === "string" ? value : undefined;
+}
+
+function isAbortError(err: unknown): boolean {
+  return !!err && typeof err === "object" && (err as { name?: unknown }).name === "AbortError";
+}
+
+function combinedFallbackError(primaryErr: unknown, fallbackErr: unknown): Error {
+  const message =
+    `Primary and fallback model calls failed. Primary: ${errorMessage(primaryErr)}; ` +
+    `Fallback: ${errorMessage(fallbackErr)}`;
+  return new Error(message, { cause: { primary: primaryErr, fallback: fallbackErr } });
+}
+
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/core/src/providers/fallback.ts
+++ b/packages/core/src/providers/fallback.ts
@@ -1,10 +1,12 @@
-import type { LanguageModel } from "ai";
+import { wrapLanguageModel, type LanguageModel } from "ai";
 
 type ResolvedLanguageModel = Extract<LanguageModel, { doGenerate: unknown }>;
 
 export interface FallbackOptions {
   maxInputTokens?: number;
   allowFor?: ("query" | "mutate" | "chat")[];
+  /** Opt-in: retry a 429 (rate limit) against the fallback. Off by default. */
+  retry429?: boolean;
 }
 
 /**
@@ -16,70 +18,76 @@ export interface FallbackOptions {
 export function withFallback(
   primary: LanguageModel,
   fallback: LanguageModel,
-  _opts: FallbackOptions = {}
+  opts: FallbackOptions = {}
 ): LanguageModel {
-  const primaryModel = primary as ResolvedLanguageModel;
   const fallbackModel = fallback as ResolvedLanguageModel;
-  return {
-    ...primaryModel,
-    async doGenerate(options) {
-      try {
-        return await primaryModel.doGenerate(options);
-      } catch (err) {
-        if (!isRetryableError(err)) throw err;
+  return wrapLanguageModel({
+    model: primary as ResolvedLanguageModel,
+    middleware: {
+      wrapGenerate: async ({ doGenerate, params }) => {
         try {
-          return await fallbackModel.doGenerate(options);
-        } catch (fallbackErr) {
-          throw combinedFallbackError(err, fallbackErr);
+          return await doGenerate();
+        } catch (err) {
+          if (!isRetryableError(err, opts.retry429)) throw err;
+          try {
+            return await fallbackModel.doGenerate(params);
+          } catch (fallbackErr) {
+            throw combinedFallbackError(err, fallbackErr);
+          }
         }
-      }
-    },
-    async doStream(options) {
-      try {
-        return await primaryModel.doStream(options);
-      } catch (err) {
-        // This only catches stream setup failures. Once a stream has been
-        // returned to the caller, later stream errors must propagate; they
-        // cannot be transparently failed over without replaying emitted events.
-        if (!isRetryableError(err)) throw err;
+      },
+      wrapStream: async ({ doStream, params }) => {
         try {
-          return await fallbackModel.doStream(options);
-        } catch (fallbackErr) {
-          throw combinedFallbackError(err, fallbackErr);
+          return await doStream();
+        } catch (err) {
+          // This only catches stream setup failures. Once a stream has been
+          // returned to the caller, later stream errors must propagate; they
+          // cannot be transparently failed over without replaying emitted events.
+          if (!isRetryableError(err, opts.retry429)) throw err;
+          try {
+            return await fallbackModel.doStream(params);
+          } catch (fallbackErr) {
+            throw combinedFallbackError(err, fallbackErr);
+          }
         }
-      }
+      },
     },
-  } as LanguageModel;
+  });
 }
 
 /**
  * Positive allowlist: retry only on recognized transport/provider failures.
- * 401/403/AbortError are NOT retryable. 429 retries are opt-in via
- * LLM_FALLBACK_RETRY_429=true.
+ * 401/403/AbortError are NOT retryable. 429 retries are opt-in via the
+ * `retry429` option (wired from LLM_FALLBACK_RETRY_429 by the caller).
  */
-export function isRetryableError(err: unknown): boolean {
-  if (typeof err === "number") return isRetryableStatusCode(err);
+export function isRetryableError(err: unknown, retry429?: boolean): boolean {
+  if (typeof err === "number") return isRetryableStatusCode(err, retry429);
   if (isAbortError(err)) return false;
+
+  // Check status code first — it is more specific than the generic
+  // isRetryable flag. This ensures {statusCode: 429, isRetryable: true}
+  // still gates on the retry429 opt-in instead of bypassing it.
+  const statusCode = getStatusCode(err);
+  if (statusCode != null) return isRetryableStatusCode(statusCode, retry429);
 
   // AI SDK wraps transport failures in RetryError with isRetryable: true.
   if (getIsRetryable(err)) return true;
-
-  const statusCode = getStatusCode(err);
-  if (statusCode != null) return isRetryableStatusCode(statusCode);
 
   // Walk the error and its cause chain for transport codes.
   const code = getDeepErrorCode(err);
   if (code && isTransportCode(code)) return true;
 
-  // Node/undici fetch failures commonly surface as TypeError.
-  if (err instanceof TypeError) return true;
+  // Node/undici network failures surface as TypeError("fetch failed").
+  // Match on the message too — an unrelated TypeError from a real bug
+  // should propagate, not be silently swallowed by a fallback.
+  if (err instanceof TypeError && errorMessage(err).includes("fetch failed")) return true;
 
   return false;
 }
 
-function isRetryableStatusCode(statusCode: number): boolean {
+function isRetryableStatusCode(statusCode: number, retry429?: boolean): boolean {
   if (statusCode === 401 || statusCode === 403) return false;
-  if (statusCode === 429) return process.env.LLM_FALLBACK_RETRY_429 === "true";
+  if (statusCode === 429) return retry429 === true;
   return statusCode === 408 || (statusCode >= 500 && statusCode < 600);
 }
 

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -30,7 +30,11 @@ function parseFormat(value: string | undefined, fallback: ApiFormat, envName: st
   return format;
 }
 
+let legacyNoticed = false;
+
 function legacyNotice(): void {
+  if (legacyNoticed) return;
+  legacyNoticed = true;
   console.error(LEGACY_NOTICE);
 }
 

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -154,7 +154,7 @@ const discoveryCache = new Map<string, { promise: Promise<string>; expiresAt: nu
  * the first listed. Results are cached per URL with a 60s TTL so model
  * swaps are noticed within a session.
  */
-async function discoverLlamaCppModel(baseURL: string): Promise<string> {
+export async function discoverLlamaCppModel(baseURL: string): Promise<string> {
   const url = normalizeV1(baseURL);
   const cached = discoveryCache.get(url);
   if (cached && cached.expiresAt > Date.now()) {

--- a/packages/core/src/providers/index.ts
+++ b/packages/core/src/providers/index.ts
@@ -1,45 +1,20 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { createOpenAICompatible } from "@ai-sdk/openai-compatible";
-import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import type { LanguageModel } from "ai";
 
-export type ProviderName = "anthropic" | "openrouter" | "llamacpp" | "local";
+type ResolvedLanguageModel = Extract<LanguageModel, { doGenerate: unknown }>;
 
-const PROVIDER_NAMES: ProviderName[] = ["anthropic", "openrouter", "llamacpp", "local"];
+export type ApiFormat = "openai" | "anthropic";
 
-export interface ProviderConfig {
-  /** Default provider, from LLM_PROVIDER env. */
-  provider: ProviderName;
-  /** Default model id for that provider, from LLM_MODEL env. */
+export interface ModelConfig {
+  baseURL: string;
+  apiKey: string;
+  format: ApiFormat;
   model: string;
 }
 
-const DEFAULT_MODELS: Record<ProviderName, string> = {
-  anthropic: "claude-sonnet-5",
-  openrouter: "anthropic/claude-sonnet-5",
-  llamacpp: "", // auto-discovered from /v1/models
-  local: "local-model",
-};
-
-export function loadProviderConfig(env: NodeJS.ProcessEnv = process.env): ProviderConfig {
-  const provider = (env.LLM_PROVIDER ?? "anthropic") as ProviderName;
-  if (!PROVIDER_NAMES.includes(provider)) {
-    throw new Error(
-      `Unknown LLM_PROVIDER "${env.LLM_PROVIDER}" (${PROVIDER_NAMES.join("|")})`
-    );
-  }
-  return { provider, model: env.LLM_MODEL ?? DEFAULT_MODELS[provider] };
-}
-
-/** Providers the current env has credentials/config for (drives the UI picker). */
-export function availableProviders(env: NodeJS.ProcessEnv = process.env): ProviderName[] {
-  const out: ProviderName[] = [];
-  if (env.ANTHROPIC_API_KEY) out.push("anthropic");
-  if (env.OPENROUTER_API_KEY) out.push("openrouter");
-  if (env.LLAMACPP_BASE_URL) out.push("llamacpp");
-  if (env.LOCAL_BASE_URL) out.push("local");
-  return out;
-}
+const LEGACY_NOTICE =
+  "[understory] using legacy env vars. Migrate to LLM_API_BASE_URL + LLM_API_KEY + LLM_API_FORMAT.";
 
 /** Ensure the URL ends in /v1 — llama-server serves the OpenAI API there. */
 function normalizeV1(baseURL: string): string {
@@ -47,20 +22,139 @@ function normalizeV1(baseURL: string): string {
   return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
 }
 
-// llama-server (or llama-swap in front of it) exposes GET /v1/models.
+function parseFormat(value: string | undefined, fallback: ApiFormat, envName: string): ApiFormat {
+  const format = value ?? fallback;
+  if (format !== "openai" && format !== "anthropic") {
+    throw new Error(`${envName} must be "openai" or "anthropic"`);
+  }
+  return format;
+}
+
+function legacyNotice(): void {
+  console.error(LEGACY_NOTICE);
+}
+
+function legacyConfig(env: NodeJS.ProcessEnv): ModelConfig | null {
+  const provider = env.LLM_PROVIDER;
+  if (provider) {
+    switch (provider) {
+      case "anthropic":
+        if (!env.ANTHROPIC_API_KEY) throw new Error("ANTHROPIC_API_KEY is required for legacy anthropic provider");
+        legacyNotice();
+        return {
+          baseURL: "https://api.anthropic.com/v1",
+          apiKey: env.ANTHROPIC_API_KEY,
+          format: "anthropic",
+          model: env.LLM_MODEL ?? "claude-sonnet-5",
+        };
+      case "openrouter":
+        if (!env.OPENROUTER_API_KEY) throw new Error("OPENROUTER_API_KEY is required for legacy openrouter provider");
+        legacyNotice();
+        return {
+          baseURL: "https://openrouter.ai/api/v1",
+          apiKey: env.OPENROUTER_API_KEY,
+          format: "openai",
+          model: env.LLM_MODEL ?? "anthropic/claude-sonnet-5",
+        };
+      case "llamacpp":
+        if (!env.LLAMACPP_BASE_URL) throw new Error("LLAMACPP_BASE_URL is required for legacy llamacpp provider");
+        legacyNotice();
+        return {
+          baseURL: env.LLAMACPP_BASE_URL,
+          apiKey: env.LLAMACPP_API_KEY ?? "not-needed",
+          format: "openai",
+          model: env.LLM_MODEL ?? "",
+        };
+      case "deepseek":
+        if (!env.DEEPSEEK_API_KEY) throw new Error("DEEPSEEK_API_KEY is required for legacy deepseek provider");
+        legacyNotice();
+        return {
+          baseURL: "https://api.deepseek.com/v1",
+          apiKey: env.DEEPSEEK_API_KEY,
+          format: "openai",
+          model: env.LLM_MODEL ?? "deepseek-chat",
+        };
+      case "local":
+        if (!env.LOCAL_BASE_URL) throw new Error("LOCAL_BASE_URL is required for legacy local provider");
+        legacyNotice();
+        return {
+          baseURL: env.LOCAL_BASE_URL,
+          apiKey: env.LOCAL_API_KEY ?? "not-needed",
+          format: "openai",
+          model: env.LLM_MODEL ?? "local-model",
+        };
+      default:
+        throw new Error(`Unknown legacy LLM_PROVIDER "${provider}" (anthropic|openrouter|llamacpp|deepseek|local)`);
+    }
+  }
+
+  const configured = [
+    env.ANTHROPIC_API_KEY ? "ANTHROPIC_API_KEY" : null,
+    env.OPENROUTER_API_KEY ? "OPENROUTER_API_KEY" : null,
+    env.LLAMACPP_BASE_URL ? "LLAMACPP_BASE_URL" : null,
+    env.DEEPSEEK_API_KEY ? "DEEPSEEK_API_KEY" : null,
+    env.LOCAL_BASE_URL ? "LOCAL_BASE_URL" : null,
+  ].filter(Boolean) as string[];
+
+  if (configured.length === 0) return null;
+  if (configured.length === 1 && configured[0] === "ANTHROPIC_API_KEY") {
+    legacyNotice();
+    return {
+      baseURL: "https://api.anthropic.com/v1",
+      apiKey: env.ANTHROPIC_API_KEY!,
+      format: "anthropic",
+      model: env.LLM_MODEL ?? "claude-sonnet-5",
+    };
+  }
+
+  throw new Error(
+    `Ambiguous legacy LLM configuration (${configured.join(", ")}). Set LLM_API_BASE_URL + LLM_API_KEY + LLM_API_FORMAT, or set LLM_PROVIDER explicitly.`
+  );
+}
+
+export function resolveModelConfig(env: NodeJS.ProcessEnv = process.env): ModelConfig {
+  if (env.LLM_API_BASE_URL) {
+    return {
+      baseURL: env.LLM_API_BASE_URL,
+      apiKey: env.LLM_API_KEY ?? "not-needed",
+      format: parseFormat(env.LLM_API_FORMAT, "openai", "LLM_API_FORMAT"),
+      model: env.LLM_MODEL ?? "",
+    };
+  }
+
+  const legacy = legacyConfig(env);
+  if (legacy) return legacy;
+
+  throw new Error(
+    "No LLM configured. Set LLM_API_BASE_URL + LLM_API_KEY + LLM_API_FORMAT + LLM_MODEL."
+  );
+}
+
+export function resolveFallbackConfig(env: NodeJS.ProcessEnv = process.env): ModelConfig | null {
+  if (!env.LLM_FALLBACK_API_BASE_URL) return null;
+  return {
+    baseURL: env.LLM_FALLBACK_API_BASE_URL,
+    apiKey: env.LLM_FALLBACK_API_KEY ?? "not-needed",
+    format: parseFormat(env.LLM_FALLBACK_API_FORMAT, "openai", "LLM_FALLBACK_API_FORMAT"),
+    model: env.LLM_FALLBACK_MODEL ?? "",
+  };
+}
+
+// Any OpenAI-compatible endpoint exposes GET /v1/models.
 // Cache discovery per base URL for a short TTL — avoids a discovery
 // round-trip on every single agent turn, while still noticing within a
-// session that the user swapped which model llama-swap has loaded (a
-// process-lifetime cache would never see that again without a restart).
+// session that the user swapped which model (e.g. via llama-swap) has
+// loaded (a process-lifetime cache would never see that again).
 const DISCOVERY_TTL_MS = 60_000;
 const discoveryCache = new Map<string, { promise: Promise<string>; expiresAt: number }>();
 
 /**
- * Pick a model id from llama-server's /v1/models. Prefers a model llama-swap
- * reports as "loaded" (avoids a multi-minute model swap); falls back to the
- * first listed. Plain llama-server lists exactly one model, no status field.
+ * Auto-discover the model id from an OpenAI-compatible /v1/models endpoint.
+ * Prefers a model reported as "loaded" (e.g. by llama-swap); falls back to
+ * the first listed. Results are cached per URL with a 60s TTL so model
+ * swaps are noticed within a session.
  */
-export async function discoverLlamaCppModel(baseURL: string): Promise<string> {
+async function discoverLlamaCppModel(baseURL: string): Promise<string> {
   const url = normalizeV1(baseURL);
   const cached = discoveryCache.get(url);
   if (cached && cached.expiresAt > Date.now()) {
@@ -69,14 +163,14 @@ export async function discoverLlamaCppModel(baseURL: string): Promise<string> {
   const promise = (async () => {
     const res = await fetch(`${url}/models`);
     if (!res.ok) {
-      throw new Error(`llama-server model discovery failed: ${res.status} at ${url}/models`);
+      throw new Error(`Model discovery failed: ${res.status} at ${url}/models`);
     }
     const body = (await res.json()) as {
       data?: { id: string; status?: { value?: string } }[];
     };
     const models = body.data ?? [];
     if (models.length === 0) {
-      throw new Error(`llama-server at ${url} lists no models`);
+      throw new Error(`No models listed at ${url}/models`);
     }
     const loaded = models.find((m) => m.status?.value === "loaded");
     return (loaded ?? models[0]).id;
@@ -87,43 +181,28 @@ export async function discoverLlamaCppModel(baseURL: string): Promise<string> {
   return promise;
 }
 
-export async function resolveModel(
-  provider?: ProviderName,
-  model?: string,
-  env: NodeJS.ProcessEnv = process.env
-): Promise<LanguageModel> {
-  const config = loadProviderConfig(env);
-  const p = provider ?? config.provider;
-  let m = model ?? (provider && provider !== config.provider ? DEFAULT_MODELS[p] : config.model);
+export async function createModel(cfg: ModelConfig): Promise<ResolvedLanguageModel> {
+  let model = cfg.model;
+  if (!model) {
+    if (cfg.format === "openai") {
+      try {
+        model = await discoverLlamaCppModel(cfg.baseURL);
+      } catch {
+        throw new Error("LLM_MODEL is required for this endpoint.");
+      }
+    } else {
+      throw new Error("LLM_MODEL is required for this endpoint.");
+    }
+  }
 
-  switch (p) {
-    case "anthropic": {
-      const anthropic = createAnthropic({ apiKey: env.ANTHROPIC_API_KEY });
-      return anthropic(m);
-    }
-    case "openrouter": {
-      const openrouter = createOpenRouter({ apiKey: env.OPENROUTER_API_KEY });
-      return openrouter.chat(m);
-    }
-    case "llamacpp": {
-      const baseURL = env.LLAMACPP_BASE_URL;
-      if (!baseURL) throw new Error("LLAMACPP_BASE_URL is required for the llamacpp provider");
-      if (!m) m = await discoverLlamaCppModel(baseURL);
-      const llamacpp = createOpenAICompatible({
-        name: "llamacpp",
-        baseURL: normalizeV1(baseURL),
-        // llama-server ignores auth unless started with --api-key.
-        apiKey: env.LLAMACPP_API_KEY ?? "not-needed",
-      });
-      return llamacpp(m);
-    }
-    case "local": {
-      const local = createOpenAICompatible({
-        name: "local",
-        baseURL: env.LOCAL_BASE_URL ?? "http://localhost:8080/v1",
-        apiKey: env.LOCAL_API_KEY ?? "not-needed",
-      });
-      return local(m);
-    }
+  switch (cfg.format) {
+    case "anthropic":
+      return createAnthropic({ baseURL: cfg.baseURL, apiKey: cfg.apiKey })(model) as ResolvedLanguageModel;
+    case "openai":
+      return createOpenAICompatible({
+        name: "custom",
+        baseURL: normalizeV1(cfg.baseURL),
+        apiKey: cfg.apiKey,
+      })(model) as ResolvedLanguageModel;
   }
 }

--- a/packages/core/test/providers.test.ts
+++ b/packages/core/test/providers.test.ts
@@ -81,6 +81,22 @@ describe("discoverLlamaCppModel", () => {
 // ── Generic provider config (PR #5) ────────────────────────────────
 
 describe("generic provider config", () => {
+  it("logs the legacy notice at most once per process", () => {
+    const spy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // First call should log the deprecation notice.
+      resolveModelConfig(env({ LLM_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "a" }));
+      // Second call (different legacy provider) should not log it again.
+      resolveModelConfig(env({ LLM_PROVIDER: "llamacpp", LLAMACPP_BASE_URL: "http://x:8080" }));
+      const legacyCalls = spy.mock.calls.filter(
+        (c) => typeof c[0] === "string" && c[0].includes("legacy env vars")
+      );
+      expect(legacyCalls).toHaveLength(1);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
   it("reads the primary and fallback slots from generic env vars", () => {
     expect(
       resolveModelConfig(
@@ -196,43 +212,97 @@ describe("fallback middleware", () => {
     await expect(withFallback(primary, fallback).doGenerate({} as never)).rejects.toMatchObject({ statusCode: 401 });
     expect(fallback.doGenerate).not.toHaveBeenCalled();
   });
+
+  it("preserves prototype getters like supportedUrls through the wrapper", () => {
+    const primary = fakeModel({
+      supportedUrls: { "image/*": [/.*/] },
+      provider: "test-provider",
+      modelId: "test-model-id",
+    });
+    const fallback = fakeModel();
+    const model = withFallback(primary, fallback);
+    expect(model.supportedUrls).toEqual({ "image/*": [/.*/] });
+    expect(model.provider).toBe("test-provider");
+    expect(model.modelId).toBe("test-model-id");
+    expect(model.specificationVersion).toBe("v2");
+  });
+
+  it("respects the retry429 option for fallback behavior", async () => {
+    // With retry429: false (default), a 429 should NOT trigger the fallback.
+    const primaryNoRetry = fakeModel({
+      doGenerate: vi.fn(async () => {
+        throw { statusCode: 429 };
+      }),
+    });
+    const fallbackNoRetry = fakeModel({ doGenerate: vi.fn() });
+    await expect(
+      withFallback(primaryNoRetry, fallbackNoRetry, { retry429: false }).doGenerate({} as never)
+    ).rejects.toMatchObject({ statusCode: 429 });
+    expect(fallbackNoRetry.doGenerate).not.toHaveBeenCalled();
+
+    // With retry429: true, a 429 SHOULD trigger the fallback.
+    const primaryYesRetry = fakeModel({
+      doGenerate: vi.fn(async () => {
+        throw { statusCode: 429 };
+      }),
+    });
+    const fallbackYesRetry = fakeModel({
+      doGenerate: vi.fn(async () => ({
+        content: [],
+        finishReason: "stop",
+        usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
+        warnings: [],
+      })),
+    });
+    const result = await withFallback(primaryYesRetry, fallbackYesRetry, { retry429: true }).doGenerate(
+      {} as never
+    );
+    expect(result).toMatchObject({ finishReason: "stop" });
+    expect(fallbackYesRetry.doGenerate).toHaveBeenCalledTimes(1);
+  });
 });
 
 // ── isRetryableError (PR #5) ────────────────────────────────────────
 
 describe("isRetryableError", () => {
   it("uses a conservative positive allowlist", () => {
-    const prev = process.env.LLM_FALLBACK_RETRY_429;
-    process.env.LLM_FALLBACK_RETRY_429 = "false";
-    try {
-      expect(isRetryableError({ statusCode: 408 })).toBe(true);
-      expect(isRetryableError({ statusCode: 500 })).toBe(true);
-      expect(isRetryableError({ statusCode: 502 })).toBe(true);
-      expect(isRetryableError({ statusCode: 503 })).toBe(true);
-      expect(isRetryableError({ statusCode: 504 })).toBe(true);
-      expect(isRetryableError({ statusCode: 401 })).toBe(false);
-      expect(isRetryableError({ statusCode: 403 })).toBe(false);
-      expect(isRetryableError({ statusCode: 429 })).toBe(false);
-      expect(isRetryableError(Object.assign(new Error("reset"), { code: "ECONNRESET" }))).toBe(true);
-      expect(isRetryableError(Object.assign(new Error("abort"), { name: "AbortError" }))).toBe(false);
-      expect(isRetryableError(new Error("ordinary"))).toBe(false);
-    } finally {
-      if (prev === undefined) delete process.env.LLM_FALLBACK_RETRY_429;
-      else process.env.LLM_FALLBACK_RETRY_429 = prev;
-    }
+    expect(isRetryableError({ statusCode: 408 })).toBe(true);
+    expect(isRetryableError({ statusCode: 500 })).toBe(true);
+    expect(isRetryableError({ statusCode: 502 })).toBe(true);
+    expect(isRetryableError({ statusCode: 503 })).toBe(true);
+    expect(isRetryableError({ statusCode: 504 })).toBe(true);
+    expect(isRetryableError({ statusCode: 401 })).toBe(false);
+    expect(isRetryableError({ statusCode: 403 })).toBe(false);
+    expect(isRetryableError({ statusCode: 429 }, false)).toBe(false);
+    expect(isRetryableError(Object.assign(new Error("reset"), { code: "ECONNRESET" }))).toBe(true);
+    expect(isRetryableError(Object.assign(new Error("abort"), { name: "AbortError" }))).toBe(false);
+    expect(isRetryableError(new Error("ordinary"))).toBe(false);
   });
 
-  it("respects LLM_FALLBACK_RETRY_429", () => {
-    const prev = process.env.LLM_FALLBACK_RETRY_429;
-    try {
-      process.env.LLM_FALLBACK_RETRY_429 = "true";
-      expect(isRetryableError({ statusCode: 429 })).toBe(true);
-      process.env.LLM_FALLBACK_RETRY_429 = "false";
-      expect(isRetryableError({ statusCode: 429 })).toBe(false);
-    } finally {
-      if (prev === undefined) delete process.env.LLM_FALLBACK_RETRY_429;
-      else process.env.LLM_FALLBACK_RETRY_429 = prev;
-    }
+  it("respects the retry429 flag", () => {
+    expect(isRetryableError({ statusCode: 429 }, true)).toBe(true);
+    expect(isRetryableError({ statusCode: 429 }, false)).toBe(false);
+    expect(isRetryableError({ statusCode: 429 })).toBe(false); // default: unset → not retryable
+  });
+
+  it("checks the status code before the isRetryable flag", () => {
+    // 429 + isRetryable: true with retry429: false → NOT retryable (status code wins).
+    expect(isRetryableError({ statusCode: 429, isRetryable: true }, false)).toBe(false);
+    // 429 + isRetryable: true with retry429: true → IS retryable.
+    expect(isRetryableError({ statusCode: 429, isRetryable: true }, true)).toBe(true);
+    // 500 + isRetryable: false → IS retryable (500 always is, regardless of the flag).
+    expect(isRetryableError({ statusCode: 500, isRetryable: false })).toBe(true);
+    // 401 + isRetryable: true → NOT retryable (401 is never retryable).
+    expect(isRetryableError({ statusCode: 401, isRetryable: true })).toBe(false);
+    // isRetryable: true without a status code → IS retryable (AI SDK RetryError).
+    expect(isRetryableError({ isRetryable: true })).toBe(true);
+  });
+
+  it("only retries TypeError with a fetch-failed message", () => {
+    expect(isRetryableError(new TypeError("fetch failed"))).toBe(true);
+    expect(isRetryableError(new TypeError("some other bug"))).toBe(false);
+    expect(isRetryableError(new Error("fetch failed"))).toBe(false); // not a TypeError
+    expect(isRetryableError(new TypeError(""))).toBe(false); // empty message
   });
 
   it("recognizes AI SDK RetryError and nested undici transport errors", () => {

--- a/packages/core/test/providers.test.ts
+++ b/packages/core/test/providers.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { discoverLlamaCppModel } from "../src/providers/index.js";
+import { discoverLlamaCppModel, resolveFallbackConfig, resolveModelConfig } from "../src/providers/index.js";
+import { isRetryableError, withFallback } from "../src/providers/fallback.js";
 
 function jsonResponse(body: unknown) {
   return new Response(JSON.stringify(body), { status: 200 });
+}
+
+function env(values: Record<string, string | undefined>): NodeJS.ProcessEnv {
+  return values as NodeJS.ProcessEnv;
 }
 
 // Each test uses its own base URL — discovery is cached per URL, and the
@@ -11,6 +16,12 @@ let counter = 0;
 function freshBaseURL() {
   return `http://localhost:${8080 + counter++}`;
 }
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ── Model discovery (PR #4: 60s TTL on discovery cache) ──────────
 
 describe("discoverLlamaCppModel", () => {
   beforeEach(() => {
@@ -66,3 +77,186 @@ describe("discoverLlamaCppModel", () => {
     expect(fetch).toHaveBeenCalledTimes(2);
   });
 });
+
+// ── Generic provider config (PR #5) ────────────────────────────────
+
+describe("generic provider config", () => {
+  it("reads the primary and fallback slots from generic env vars", () => {
+    expect(
+      resolveModelConfig(
+        env({
+          LLM_API_BASE_URL: "https://api.deepseek.com/v1",
+          LLM_API_KEY: "sk-test",
+          LLM_API_FORMAT: "openai",
+          LLM_MODEL: "deepseek-chat",
+        })
+      )
+    ).toEqual({
+      baseURL: "https://api.deepseek.com/v1",
+      apiKey: "sk-test",
+      format: "openai",
+      model: "deepseek-chat",
+    });
+
+    expect(
+      resolveFallbackConfig(
+        env({
+          LLM_FALLBACK_API_BASE_URL: "http://localhost:8080/v1",
+          LLM_FALLBACK_API_FORMAT: "openai",
+        })
+      )
+    ).toEqual({
+      baseURL: "http://localhost:8080/v1",
+      apiKey: "not-needed",
+      format: "openai",
+      model: "",
+    });
+  });
+
+  it("maps legacy providers to the generic model config", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(resolveModelConfig(env({ LLM_PROVIDER: "anthropic", ANTHROPIC_API_KEY: "a" }))).toMatchObject({
+      baseURL: "https://api.anthropic.com/v1",
+      apiKey: "a",
+      format: "anthropic",
+      model: "claude-sonnet-5",
+    });
+    expect(resolveModelConfig(env({ LLM_PROVIDER: "openrouter", OPENROUTER_API_KEY: "o" }))).toMatchObject({
+      baseURL: "https://openrouter.ai/api/v1",
+      apiKey: "o",
+      format: "openai",
+      model: "anthropic/claude-sonnet-5",
+    });
+    expect(resolveModelConfig(env({ LLM_PROVIDER: "llamacpp", LLAMACPP_BASE_URL: "http://localhost:8080" }))).toMatchObject({
+      baseURL: "http://localhost:8080",
+      apiKey: "not-needed",
+      format: "openai",
+      model: "",
+    });
+    expect(resolveModelConfig(env({ LLM_PROVIDER: "deepseek", DEEPSEEK_API_KEY: "d" }))).toMatchObject({
+      baseURL: "https://api.deepseek.com/v1",
+      apiKey: "d",
+      format: "openai",
+      model: "deepseek-chat",
+    });
+    expect(resolveModelConfig(env({ LLM_PROVIDER: "local", LOCAL_BASE_URL: "http://local/v1" }))).toMatchObject({
+      baseURL: "http://local/v1",
+      apiKey: "not-needed",
+      format: "openai",
+      model: "local-model",
+    });
+  });
+
+  it("keeps the historical anthropic default but fails closed on ambiguous legacy env", () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(resolveModelConfig(env({ ANTHROPIC_API_KEY: "a" }))).toMatchObject({
+      format: "anthropic",
+      apiKey: "a",
+    });
+    expect(() =>
+      resolveModelConfig(env({ ANTHROPIC_API_KEY: "a", OPENROUTER_API_KEY: "o" }))
+    ).toThrow(/Ambiguous legacy LLM configuration/);
+  });
+});
+
+// ── Fallback middleware (PR #5) ─────────────────────────────────────
+
+describe("fallback middleware", () => {
+  it("uses the fallback for retryable doGenerate and doStream setup failures", async () => {
+    const primary = fakeModel({
+      doGenerate: vi.fn(async () => {
+        throw { statusCode: 500 };
+      }),
+      doStream: vi.fn(async () => {
+        throw Object.assign(new TypeError("network"), { code: "ECONNRESET" });
+      }),
+    });
+    const fallback = fakeModel({
+      doGenerate: vi.fn(async () => ({ content: [], finishReason: "stop", usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }, warnings: [] })),
+      doStream: vi.fn(async () => ({ stream: new ReadableStream() })),
+    });
+
+    const model = withFallback(primary, fallback);
+    await expect(model.doGenerate({} as never)).resolves.toMatchObject({ finishReason: "stop" });
+    await expect(model.doStream({} as never)).resolves.toHaveProperty("stream");
+    expect(fallback.doGenerate).toHaveBeenCalledTimes(1);
+    expect(fallback.doStream).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not fallback for non-retryable errors", async () => {
+    const primary = fakeModel({
+      doGenerate: vi.fn(async () => {
+        throw { statusCode: 401 };
+      }),
+    });
+    const fallback = fakeModel({ doGenerate: vi.fn() });
+
+    await expect(withFallback(primary, fallback).doGenerate({} as never)).rejects.toMatchObject({ statusCode: 401 });
+    expect(fallback.doGenerate).not.toHaveBeenCalled();
+  });
+});
+
+// ── isRetryableError (PR #5) ────────────────────────────────────────
+
+describe("isRetryableError", () => {
+  it("uses a conservative positive allowlist", () => {
+    const prev = process.env.LLM_FALLBACK_RETRY_429;
+    process.env.LLM_FALLBACK_RETRY_429 = "false";
+    try {
+      expect(isRetryableError({ statusCode: 408 })).toBe(true);
+      expect(isRetryableError({ statusCode: 500 })).toBe(true);
+      expect(isRetryableError({ statusCode: 502 })).toBe(true);
+      expect(isRetryableError({ statusCode: 503 })).toBe(true);
+      expect(isRetryableError({ statusCode: 504 })).toBe(true);
+      expect(isRetryableError({ statusCode: 401 })).toBe(false);
+      expect(isRetryableError({ statusCode: 403 })).toBe(false);
+      expect(isRetryableError({ statusCode: 429 })).toBe(false);
+      expect(isRetryableError(Object.assign(new Error("reset"), { code: "ECONNRESET" }))).toBe(true);
+      expect(isRetryableError(Object.assign(new Error("abort"), { name: "AbortError" }))).toBe(false);
+      expect(isRetryableError(new Error("ordinary"))).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.LLM_FALLBACK_RETRY_429;
+      else process.env.LLM_FALLBACK_RETRY_429 = prev;
+    }
+  });
+
+  it("respects LLM_FALLBACK_RETRY_429", () => {
+    const prev = process.env.LLM_FALLBACK_RETRY_429;
+    try {
+      process.env.LLM_FALLBACK_RETRY_429 = "true";
+      expect(isRetryableError({ statusCode: 429 })).toBe(true);
+      process.env.LLM_FALLBACK_RETRY_429 = "false";
+      expect(isRetryableError({ statusCode: 429 })).toBe(false);
+    } finally {
+      if (prev === undefined) delete process.env.LLM_FALLBACK_RETRY_429;
+      else process.env.LLM_FALLBACK_RETRY_429 = prev;
+    }
+  });
+
+  it("recognizes AI SDK RetryError and nested undici transport errors", () => {
+    // AI SDK RetryError shape after exhausting internal retries
+    expect(isRetryableError({ isRetryable: true, message: "Failed after 3 attempts" })).toBe(true);
+    // undici error nested inside cause
+    expect(isRetryableError({ cause: { code: "UND_ERR_CONNECT_TIMEOUT" } })).toBe(true);
+    // deep nesting
+    expect(isRetryableError({ cause: { cause: { code: "ECONNRESET" } } })).toBe(true);
+    // isRetryable: false should NOT trigger
+    expect(isRetryableError({ isRetryable: false, message: "some error" })).toBe(false);
+  });
+});
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+function fakeModel(overrides: Record<string, unknown> = {}) {
+  return {
+    specificationVersion: "v2",
+    provider: "test",
+    modelId: "test-model",
+    supportedUrls: {},
+    doGenerate: async () => ({ content: [], finishReason: "stop", usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 }, warnings: [] }),
+    doStream: async () => ({ stream: new ReadableStream() }),
+    ...overrides,
+  } as any;
+}

--- a/packages/server/src/api/browse.ts
+++ b/packages/server/src/api/browse.ts
@@ -1,6 +1,11 @@
 import express, { type Router } from "express";
-import { BundleError, TraceStore, type KnowledgeBase } from "@understory/core";
-import { availableProviders, loadProviderConfig } from "@understory/core";
+import {
+  BundleError,
+  TraceStore,
+  resolveFallbackConfig,
+  resolveModelConfig,
+  type KnowledgeBase,
+} from "@understory/core";
 
 /** Deterministic browse API — no LLM involved, browsing never costs tokens. */
 export function browseRouter(kb: KnowledgeBase): Router {
@@ -74,11 +79,12 @@ export function browseRouter(kb: KnowledgeBase): Router {
   });
 
   router.get("/config", (_req, res) => {
-    const config = loadProviderConfig();
+    const config = resolveModelConfig();
+    const fallback = resolveFallbackConfig();
     res.json({
-      providers: availableProviders(),
-      defaultProvider: config.provider,
-      defaultModel: config.model,
+      model: config.model,
+      format: config.format,
+      fallbackConfigured: fallback !== null,
     });
   });
 

--- a/packages/server/src/api/chat.ts
+++ b/packages/server/src/api/chat.ts
@@ -1,10 +1,9 @@
 import express, { type Router } from "express";
 import { convertToModelMessages, type UIMessage } from "ai";
-import { streamChat, type KnowledgeBase, type ProviderName } from "@understory/core";
+import { streamChat, type KnowledgeBase } from "@understory/core";
 
 interface ChatBody {
   messages: UIMessage[];
-  provider?: ProviderName;
   model?: string;
 }
 
@@ -16,11 +15,8 @@ export function chatRouter(kb: KnowledgeBase): Router {
   const router = express.Router();
 
   router.post("/chat", async (req, res) => {
-    const { messages, provider, model } = req.body as ChatBody;
-    const { result } = await streamChat(kb, convertToModelMessages(messages), {
-      provider,
-      model,
-    });
+    const { messages, model } = req.body as ChatBody;
+    const { result } = await streamChat(kb, convertToModelMessages(messages), { model });
     const response = result.toUIMessageStreamResponse();
     res.status(response.status);
     response.headers.forEach((value, key) => res.setHeader(key, value));

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -3,7 +3,7 @@ import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import express from "express";
 import cors from "cors";
-import { KnowledgeBase } from "@understory/core";
+import { KnowledgeBase, resolveFallbackConfig, resolveModelConfig } from "@understory/core";
 import { mcpRouter } from "./mcp/http.js";
 import { browseRouter } from "./api/browse.js";
 import { chatRouter } from "./api/chat.js";
@@ -20,6 +20,24 @@ const kb = new KnowledgeBase(bundleRoot, {
 });
 
 const app = express();
+
+// Validate LLM config at startup — fail fast with a clear error.
+try {
+  const primaryConfig = resolveModelConfig();
+  console.log(
+    `[understory] model: ${primaryConfig.format}:${primaryConfig.model || "auto"} @ ${primaryConfig.baseURL}`
+  );
+  const fallbackConfig = resolveFallbackConfig();
+  if (fallbackConfig) {
+    console.log(
+      `[understory] fallback: ${fallbackConfig.format}:${fallbackConfig.model || "auto"} @ ${fallbackConfig.baseURL}`
+    );
+  }
+} catch (err) {
+  console.error(`[understory] LLM configuration error: ${(err as Error).message}`);
+  console.error("[understory] Set LLM_API_BASE_URL + LLM_API_KEY, or configure legacy env vars.");
+  process.exit(1);
+}
 
 // Reflect the request origin; expose Mcp-Session-Id so browser MCP clients can
 // read it back off the initialize response.

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
-import { KnowledgeBase, runQuery, runMutation } from "@understory/core";
+import { KnowledgeBase, runQuery, runMutation, type MutationOutcome } from "@understory/core";
 import { buildSeedMemory, seedInstructions } from "./seed.js";
 
 /**
@@ -61,6 +61,34 @@ export async function buildMcpServer(kb: KnowledgeBase): Promise<McpServer> {
     }
   };
 
+  const mutationOutcomeResponse = (outcome: MutationOutcome) => {
+    if (outcome.ok) {
+      const { summary, filesChanged } = outcome.result;
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `${summary}\n\nFiles changed:\n${filesChanged.map((f) => `- ${f}`).join("\n") || "- none"}`,
+          },
+        ],
+      };
+    }
+    if (outcome.status === "partial") {
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `⚠ Partial mutation: ${outcome.filesChanged.length} file(s) written before failure.\nFiles: ${outcome.filesChanged.join(", ")}\nError: ${outcome.error}`,
+          },
+        ],
+      };
+    }
+    return {
+      content: [{ type: "text" as const, text: `Mutation failed: ${outcome.error}` }],
+      isError: true,
+    };
+  };
+
   server.registerTool(
     "memory_add",
     {
@@ -89,13 +117,9 @@ export async function buildMcpServer(kb: KnowledgeBase): Promise<McpServer> {
         `must use the write tools.\n\n` +
         `KNOWLEDGE TO RECORD:\n${content}` +
         (suggested_path ? `\n\nIf it fits, place new content at ${suggested_path}.` : "");
-      const { summary, filesChanged } = await runMutation(kb, instruction);
+      const outcome = await runMutation(kb, instruction);
       await refreshSeed();
-      return {
-        content: [
-          { type: "text", text: `${summary}\n\nFiles changed:\n${filesChanged.map((f) => `- ${f}`).join("\n") || "- none"}` },
-        ],
-      };
+      return mutationOutcomeResponse(outcome);
     }
   );
 
@@ -110,13 +134,9 @@ export async function buildMcpServer(kb: KnowledgeBase): Promise<McpServer> {
       },
     },
     async ({ instruction }) => {
-      const { summary, filesChanged } = await runMutation(kb, instruction);
+      const outcome = await runMutation(kb, instruction);
       await refreshSeed();
-      return {
-        content: [
-          { type: "text", text: `${summary}\n\nFiles changed:\n${filesChanged.map((f) => `- ${f}`).join("\n") || "- none"}` },
-        ],
-      };
+      return mutationOutcomeResponse(outcome);
     }
   );
 
@@ -196,8 +216,10 @@ export async function buildMcpServer(kb: KnowledgeBase): Promise<McpServer> {
         `or remove the link if the target is gone.\n${brokenList}\n\n` +
         `Follow the enrich / link-both-ways rules. Read concepts before editing.`;
 
-      const { summary, filesChanged } = await runMutation(kb, instruction);
+      const outcome = await runMutation(kb, instruction);
       await refreshSeed();
+      if (!outcome.ok) return mutationOutcomeResponse(outcome);
+      const { summary, filesChanged } = outcome.result;
       const after = await kb.lint();
       return {
         content: [

--- a/packages/server/src/mcp/stdio.ts
+++ b/packages/server/src/mcp/stdio.ts
@@ -5,12 +5,32 @@
  *     -e LLM_PROVIDER=openrouter -- node <repo>/packages/server/dist/mcp/stdio.js
  */
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
-import { KnowledgeBase } from "@understory/core";
+import { KnowledgeBase, resolveFallbackConfig, resolveModelConfig } from "@understory/core";
 import { buildMcpServer } from "./server.js";
 
 const bundleRoot = process.env.BUNDLE_ROOT;
 if (!bundleRoot) {
   console.error("BUNDLE_ROOT env var is required");
+  process.exit(1);
+}
+
+// Validate LLM config at startup — fail fast with a clear error. stdio's
+// only output channel to the user is stderr; stdout is reserved for the
+// MCP protocol stream.
+try {
+  const primaryConfig = resolveModelConfig();
+  console.error(
+    `[understory] model: ${primaryConfig.format}:${primaryConfig.model || "auto"} @ ${primaryConfig.baseURL}`
+  );
+  const fallbackConfig = resolveFallbackConfig();
+  if (fallbackConfig) {
+    console.error(
+      `[understory] fallback: ${fallbackConfig.format}:${fallbackConfig.model || "auto"} @ ${fallbackConfig.baseURL}`
+    );
+  }
+} catch (err) {
+  console.error(`[understory] LLM configuration error: ${(err as Error).message}`);
+  console.error("[understory] Set LLM_API_BASE_URL + LLM_API_KEY, or configure legacy env vars.");
   process.exit(1);
 }
 

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -72,9 +72,9 @@ export interface QueryTrace extends TraceSummary {
 }
 
 export interface AppConfig {
-  providers: string[];
-  defaultProvider: string;
-  defaultModel: string;
+  model: string;
+  format: "openai" | "anthropic" | string;
+  fallbackConfigured: boolean;
 }
 
 const TOKEN_KEY = "understory-token";

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -21,12 +21,12 @@ export function ChatPanel({
   onOpenConcept: (path: string) => void;
 }) {
   const [input, setInput] = useState("");
-  const [provider, setProvider] = useState<string | undefined>(undefined);
+  const [model, setModel] = useState("");
   const { messages, sendMessage, status } = useChat({
     transport: new DefaultChatTransport({
       api: "/api/chat",
       headers: () => authHeaders(),
-      body: () => ({ provider }),
+      body: () => ({ model: model || undefined }),
     }),
     onFinish: () => onMutation(), // refresh browse pane; agent may have written files
   });
@@ -38,17 +38,17 @@ export function ChatPanel({
       <div className="flex items-center gap-2 border-b border-zinc-800 px-3 py-2">
         <span className="text-sm font-semibold text-zinc-300">Agent chat</span>
         {config && (
-          <select
-            value={provider ?? config.defaultProvider}
-            onChange={(e) => setProvider(e.target.value)}
-            className="ml-auto rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 text-xs text-zinc-300"
-          >
-            {config.providers.map((p) => (
-              <option key={p} value={p}>
-                {p}
-              </option>
-            ))}
-          </select>
+          <div className="ml-auto flex items-center gap-1.5">
+            {config.fallbackConfigured && (
+              <span title="Fallback model configured" className="h-1.5 w-1.5 rounded-full bg-emerald-400" />
+            )}
+            <input
+              value={model}
+              onChange={(e) => setModel(e.target.value)}
+              placeholder={config.model}
+              className="w-32 rounded border border-zinc-700 bg-zinc-900 px-1.5 py-0.5 text-xs text-zinc-300 outline-none focus:border-cyan-600"
+            />
+          </div>
         )}
       </div>
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,9 +16,6 @@ importers:
       '@ai-sdk/openai-compatible':
         specifier: ^1.0.0
         version: 1.0.42(zod@3.25.76)
-      '@openrouter/ai-sdk-provider':
-        specifier: ^1.0.0
-        version: 1.5.4(ai@5.0.210(zod@3.25.76))(zod@3.25.76)
       ai:
         specifier: ^5.0.0
         version: 5.0.210(zod@3.25.76)
@@ -622,16 +619,6 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
-
-  '@openrouter/ai-sdk-provider@1.5.4':
-    resolution: {integrity: sha512-xrSQPUIH8n9zuyYZR0XK7Ba0h2KsjJcMkxnwaYfmv13pKs3sDkjPzVPPhlhzqBGddHb5cFEwJ9VFuFeDcxCDSw==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      ai: ^5.0.0
-      zod: ^3.24.1 || ^v4
-
-  '@openrouter/sdk@0.1.27':
-    resolution: {integrity: sha512-RH//L10bSmc81q25zAZudiI4kNkLgxF2E+WU42vghp3N6TEvZ6F0jK7uT3tOxkEn91gzmMw9YVmDENy7SJsajQ==}
 
   '@opentelemetry/api@1.9.0':
     resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
@@ -2508,16 +2495,6 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
-
-  '@openrouter/ai-sdk-provider@1.5.4(ai@5.0.210(zod@3.25.76))(zod@3.25.76)':
-    dependencies:
-      '@openrouter/sdk': 0.1.27
-      ai: 5.0.210(zod@3.25.76)
-      zod: 3.25.76
-
-  '@openrouter/sdk@0.1.27':
-    dependencies:
-      zod: 3.25.76
 
   '@opentelemetry/api@1.9.0': {}
 


### PR DESCRIPTION
First — thanks @thecodacus for this project and everything you put into the open-source community. Your channel has been a constant source of practical, no-nonsense guidance, and understory itself is exactly the kind of tool that makes the local-first LLM ecosystem actually usable day-to-day. This PR tries to extend that same philosophy.

---

I run understory local-first — my daily driver is a llama.cpp server on my homelab. But I wanted two things the current hardcoded provider system could not give me:

1. **Use any provider without waiting for a code change** — DeepSeek, Groq, Together, whatever drops next week
2. **A fallback for when the primary is unreachable** — internet drops, llama-server OOMs, API outage

Even for someone committed to local models, fallback is just pragmatic. Cheap cloud APIs or a second local server on another box cost almost nothing and mean your memory does not go silent when something breaks. The goal is not "add cloud support" — it is "your memory works reliably, period."

### What changed

The provider system went from 4 hardcoded providers + 8 env vars to **two generic slots** — primary and optional fallback:

```bash
# Before: one of 4 hardcoded providers
LLM_PROVIDER=anthropic
ANTHROPIC_API_KEY=sk-...

# After: any OpenAI or Anthropic-compatible API, zero code changes
LLM_API_BASE_URL=https://api.deepseek.com/v1
LLM_API_KEY=sk-...
LLM_API_FORMAT=openai
LLM_MODEL=deepseek-chat

# Optional fallback — tried automatically when the primary fails
LLM_FALLBACK_API_BASE_URL=http://llamacpp:8080
LLM_FALLBACK_ALLOW_FOR=query        # scope-gate: query only, or * for all
LLM_FALLBACK_RETRY_429=true         # opt-in: fallback on rate-limit exhaustion
```

**Every existing deployment keeps working.** The old `LLM_PROVIDER` + per-provider key vars are mapped automatically with a deprecation notice.

### How the fallback works

A `withFallback()` middleware wraps at the AI SDK `doGenerate`/`doStream` level — not at the agent level. If the primary model call fails with a transport error (timeout, 5xx, connection refused), the middleware swaps to the fallback **for that one generation step**. No whole-agent replay, no risk of double-mutating the knowledge base.

Tested by blocking `api.deepseek.com:443` with iptables — the local Gemma model picked up the query transparently:

```json
{
  "outcome": "success",
  "modelChain": [
    "openai:deepseek-v4-flash@https://api.deepseek.com",
    "openai:gemma-4-12b@http://llamacpp:8080"
  ]
}
```

### What was deleted

- `ProviderName` union + `availableProviders()` + `loadProviderConfig()` + 50-line `resolveModel()` switch
- `@openrouter/ai-sdk-provider` dependency (works fine through the generic OpenAI-compatible path)
- UI provider dropdown → model text field (the dropdown was limited to hardcoded names anyway)

### What was added

- `ModelConfig` + `resolveModelConfig()` + `resolveFallbackConfig()` + `createModel()` — two format adapters
- `withFallback()` middleware + `isRetryableError()` with cause-chain walking for undici/AI SDK errors
- `MutationOutcome` discriminated union — partial/failed mutations instead of silent errors
- Trace fields: `outcome` + `modelChain`
- Fail-fast config validation at server startup
- 8 new tests (26 total)

### Migration (zero-config for existing users)

| Old | What happens |
|---|---|
| `LLM_PROVIDER=anthropic` | Mapped automatically, deprecation notice in logs |
| `LLM_PROVIDER=llamacpp` | Mapped + auto-discovery — identical behavior |
| `LLM_PROVIDER=openrouter` | Generic OpenAI-compatible path, no dependency needed |
| No `LLM_API_BASE_URL` set | Legacy mapping kicks in — nothing changes |

To migrate: replace `LLM_PROVIDER` + per-provider key with `LLM_API_BASE_URL` + `LLM_API_KEY` + `LLM_API_FORMAT`.