### PR TITLE
feat: add optional bearer-token auth for /mcp and /api

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ ANTHROPIC_API_KEY=
 GIT_AUTOCOMMIT=false
 
 PORT=3800
+
+# Optional: require "Authorization: Bearer <token>" on /mcp and /api.
+# Unset = open (fine for localhost/LAN). Set this before exposing understory anywhere.
+#AUTH_TOKEN=

--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ claude mcp add ustory \
 
 Or point an HTTP MCP client at `http://host:3800/mcp`.
 
+### Auth
+
+By default the server is open — fine on localhost or a trusted LAN. Before exposing it anywhere else, set `AUTH_TOKEN`:
+
+```bash
+AUTH_TOKEN=$(openssl rand -hex 24)
+```
+
+With it set, `/mcp` and `/api` require `Authorization: Bearer <token>` (the web UI stays reachable and prompts for the token). Register authenticated MCP clients with a header:
+
+```bash
+claude mcp add --transport http ustory http://host:3800/mcp \
+  --header "Authorization: Bearer <token>"
+```
+
+The stdio transport needs no token — it's a local process spawned by the client.
+
 ### Seed memory
 
 A client LLM that only sees four bare tool names never gets the instinct to check memory. So at **session start** the server injects a compact overview of what the knowledge base contains (directories, concepts with types + descriptions, recent activity) through both channels that reach the model:

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -12,6 +12,7 @@ services:
       - okf-bundle:/bundle
     environment:
       BUNDLE_ROOT: /bundle
+      AUTH_TOKEN: ${AUTH_TOKEN:-}
       # anthropic | openrouter | llamacpp | local
       LLM_PROVIDER: ${LLM_PROVIDER:-llamacpp}
       LLM_MODEL: ${LLM_MODEL:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - ./sample-bundle:/bundle
     environment:
       BUNDLE_ROOT: /bundle
+      AUTH_TOKEN: ${AUTH_TOKEN:-}
       LLM_PROVIDER: ${LLM_PROVIDER:-anthropic}
       LLM_MODEL: ${LLM_MODEL:-}
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}

--- a/packages/server/src/auth.ts
+++ b/packages/server/src/auth.ts
@@ -1,0 +1,30 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { NextFunction, Request, Response } from "express";
+
+/**
+ * Optional bearer-token auth for /mcp and /api (issue #1).
+ * AUTH_TOKEN unset → no auth (localhost/homelab default).
+ * AUTH_TOKEN set   → requests must carry `Authorization: Bearer <token>`.
+ * The static web UI stays open; it prompts for the token and sends it on
+ * its API calls. The stdio MCP transport is unaffected (local process).
+ */
+export function bearerAuth(token: string) {
+  const expected = sha256(token);
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const header = req.headers.authorization ?? "";
+    const provided = header.startsWith("Bearer ") ? header.slice(7) : "";
+    // Hash both sides so timingSafeEqual gets equal-length buffers.
+    if (provided && timingSafeEqual(sha256(provided), expected)) {
+      next();
+      return;
+    }
+    res
+      .status(401)
+      .set("WWW-Authenticate", 'Bearer realm="understory"')
+      .json({ error: "unauthorized: set Authorization: Bearer <AUTH_TOKEN>" });
+  };
+}
+
+function sha256(value: string): Buffer {
+  return createHash("sha256").update(value).digest();
+}

--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -7,6 +7,7 @@ import { KnowledgeBase } from "@understory/core";
 import { mcpRouter } from "./mcp/http.js";
 import { browseRouter } from "./api/browse.js";
 import { chatRouter } from "./api/chat.js";
+import { bearerAuth } from "./auth.js";
 
 const bundleRoot = process.env.BUNDLE_ROOT;
 if (!bundleRoot) {
@@ -38,6 +39,16 @@ app.use(
   })
 );
 app.use(express.json({ limit: "4mb" }));
+
+// Optional bearer auth (issue #1): protects the memory (/mcp + /api) when
+// AUTH_TOKEN is set. Static web UI stays open and prompts for the token.
+const authToken = process.env.AUTH_TOKEN;
+if (authToken) {
+  app.use(["/mcp", "/api"], bearerAuth(authToken));
+  console.log("[understory] auth: bearer token required for /mcp and /api");
+} else {
+  console.log("[understory] auth: disabled (set AUTH_TOKEN to protect /mcp and /api)");
+}
 
 app.use("/mcp", mcpRouter(kb));
 app.use("/api", browseRouter(kb));

--- a/packages/server/test/auth.test.ts
+++ b/packages/server/test/auth.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from "vitest";
+import type { Request, Response } from "express";
+import { bearerAuth } from "../src/auth.js";
+
+function call(middleware: ReturnType<typeof bearerAuth>, authorization?: string) {
+  const req = { headers: authorization ? { authorization } : {} } as Request;
+  const set = vi.fn().mockReturnThis();
+  const json = vi.fn().mockReturnThis();
+  const status = vi.fn().mockReturnValue({ set, json } as unknown as Response);
+  const res = { status } as unknown as Response;
+  // status().set().json() chain
+  (status as ReturnType<typeof vi.fn>).mockReturnValue({ set: set.mockReturnValue({ json }) });
+  const next = vi.fn();
+  middleware(req, res, next);
+  return { next, status };
+}
+
+describe("bearerAuth", () => {
+  const middleware = bearerAuth("s3cret-token");
+
+  it("passes requests with the correct bearer token", () => {
+    const { next, status } = call(middleware, "Bearer s3cret-token");
+    expect(next).toHaveBeenCalledOnce();
+    expect(status).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing, malformed, and wrong tokens with 401", () => {
+    for (const header of [undefined, "Bearer wrong", "Bearer ", "s3cret-token", "Basic s3cret-token"]) {
+      const { next, status } = call(middleware, header);
+      expect(next).not.toHaveBeenCalled();
+      expect(status).toHaveBeenCalledWith(401);
+    }
+  });
+
+  it("rejects tokens of different lengths without throwing (timing-safe hash path)", () => {
+    const { next, status } = call(middleware, "Bearer x");
+    expect(next).not.toHaveBeenCalled();
+    expect(status).toHaveBeenCalledWith(401);
+  });
+});

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { api, type AppConfig, type Concept, type ConformanceReport, type LogEntry, type SearchHit, type TreeNode } from "./api";
+import { api, ApiError, setAuthToken, type AppConfig, type Concept, type ConformanceReport, type LogEntry, type SearchHit, type TreeNode } from "./api";
 import { Tree } from "./components/Tree";
 import { ConceptView } from "./components/ConceptView";
 import { LogView } from "./components/LogView";
@@ -23,9 +23,20 @@ export default function App() {
   const [hits, setHits] = useState<SearchHit[] | null>(null);
   const [chatOpen, setChatOpen] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [needsToken, setNeedsToken] = useState(false);
+  const [tokenInput, setTokenInput] = useState("");
 
   const refresh = useCallback(() => {
-    api.tree().then(setTree).catch((e) => setError(String(e)));
+    api
+      .tree()
+      .then((t) => {
+        setTree(t);
+        setNeedsToken(false);
+      })
+      .catch((e) => {
+        if (e instanceof ApiError && e.status === 401) setNeedsToken(true);
+        else setError(String(e));
+      });
     api.validate().then(setReport).catch(() => {});
     api.log().then(setLog).catch(() => {});
   }, []);
@@ -67,6 +78,42 @@ export default function App() {
     setError(null);
     setQuery("");
   }, []);
+
+  if (needsToken) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            setAuthToken(tokenInput.trim());
+            setTokenInput("");
+            refresh();
+            api.config().then(setConfig).catch(() => {});
+          }}
+          className="w-80 rounded-xl border border-zinc-800 bg-zinc-900/60 p-5"
+        >
+          <h1 className="text-sm font-bold tracking-wide text-cyan-300">understory 🌱</h1>
+          <p className="mt-2 text-sm text-zinc-400">
+            This server requires an access token (its <code className="text-zinc-300">AUTH_TOKEN</code>).
+          </p>
+          <input
+            type="password"
+            value={tokenInput}
+            onChange={(e) => setTokenInput(e.target.value)}
+            placeholder="Access token"
+            autoFocus
+            className="mt-3 w-full rounded-lg border border-zinc-700 bg-zinc-900 px-3 py-2 text-sm outline-none focus:border-cyan-600"
+          />
+          <button
+            type="submit"
+            className="mt-3 w-full rounded-lg bg-cyan-700 px-3 py-2 text-sm font-medium text-white hover:bg-cyan-600"
+          >
+            Unlock
+          </button>
+        </form>
+      </div>
+    );
+  }
 
   return (
     <div className="flex h-screen">

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -77,9 +77,33 @@ export interface AppConfig {
   defaultModel: string;
 }
 
+const TOKEN_KEY = "understory-token";
+
+export function getAuthToken(): string {
+  return localStorage.getItem(TOKEN_KEY) ?? "";
+}
+
+export function setAuthToken(token: string): void {
+  if (token) localStorage.setItem(TOKEN_KEY, token);
+  else localStorage.removeItem(TOKEN_KEY);
+}
+
+/** Headers for API calls — includes the bearer token when one is stored. */
+export function authHeaders(): Record<string, string> {
+  const token = getAuthToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+}
+
+export class ApiError extends Error {
+  constructor(public readonly status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
 async function get<T>(url: string): Promise<T> {
-  const res = await fetch(url);
-  if (!res.ok) throw new Error(`${res.status} ${await res.text()}`);
+  const res = await fetch(url, { headers: authHeaders() });
+  if (!res.ok) throw new ApiError(res.status, `${res.status} ${await res.text()}`);
   return res.json();
 }
 

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import ReactMarkdown from "react-markdown";
+import { authHeaders } from "../api";
 import type { AppConfig } from "../api";
 
 const WRITE_TOOLS = new Set(["write_concept", "patch_concept", "delete_concept"]);
@@ -24,6 +25,7 @@ export function ChatPanel({
   const { messages, sendMessage, status } = useChat({
     transport: new DefaultChatTransport({
       api: "/api/chat",
+      headers: () => authHeaders(),
       body: () => ({ provider }),
     }),
     onFinish: () => onMutation(), // refresh browse pane; agent may have written files


### PR DESCRIPTION
Closes #1

Set `AUTH_TOKEN` on the server and `/mcp` + `/api` require `Authorization: Bearer <token>`. Unset keeps today's open behavior for localhost/homelab setups.

- `bearerAuth` middleware: timing-safe compare (sha256 + timingSafeEqual), 401 with `WWW-Authenticate` otherwise; startup logs which auth mode is active
- Web UI stays reachable and gates itself: on 401 it prompts for the token, stores it in localStorage, and sends it on all API calls including the chat stream
- stdio MCP transport unaffected (local process spawned by the client)
- `.env.example` + both composes expose `AUTH_TOKEN`; README gains an Auth section with the `claude mcp add --header` registration
- 3 middleware tests

Verified live: 401 without/with wrong token on both `/api` and `/mcp`, 200 with the token, MCP initialize succeeds with the header, the web UI serves without a token, and unset `AUTH_TOKEN` leaves everything open.