### PR TITLE
ci: run tests on pull requests

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  pull_request:
+    branches: [main]
   workflow_dispatch:
 
 env:
@@ -25,6 +27,7 @@ jobs:
 
   publish:
     needs: test
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
Contributor PRs currently run zero checks (#4 arrived unverified) — the workflow only fired on push to main. This adds a `pull_request` trigger for the test job and gates `publish` to push events so PRs never build or publish images.