### PR TITLE
feat: layered query cache — exact cache + hot memory before the deep agent

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,3 +33,8 @@ PORT=3800
 # bundle changes. QUERY_CACHE=false disables; QUERY_CACHE_TTL e.g. "1h" (default 24h).
 #QUERY_CACHE=true
 #QUERY_CACHE_TTL=24h
+
+# Hot memory: recent writes + recent answers form a working set that queries
+# check with one cheap tool-free LLM call before the full agent run.
+#HOT_MEMORY=true
+#HOT_MEMORY_TTL=1h

--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,8 @@ PORT=3800
 # Optional: require "Authorization: Bearer <token>" on /mcp and /api.
 # Unset = open (fine for localhost/LAN). Set this before exposing understory anywhere.
 #AUTH_TOKEN=
+
+# Query cache: repeated memory_query questions answer from cache until the
+# bundle changes. QUERY_CACHE=false disables; QUERY_CACHE_TTL e.g. "1h" (default 24h).
+#QUERY_CACHE=true
+#QUERY_CACHE_TTL=24h

--- a/packages/core/src/agent/hot-memory.ts
+++ b/packages/core/src/agent/hot-memory.ts
@@ -1,0 +1,138 @@
+import type { KnowledgeBase } from "../okf/index.js";
+import { parseDuration } from "../util/duration.js";
+import type { AgentOptions } from "./agent.js";
+
+/**
+ * Hot memory: a small working set of recently written concepts and recent
+ * Q&A pairs. Queries consult it BEFORE the deep agent run — one cheap,
+ * tool-free LLM call over a tiny context. Misses fall through to deep
+ * memory (the full agent loop). Short-term memory in front of long-term.
+ *
+ * Staleness rules:
+ * - Hot concepts are stored as PATHS and read fresh at lookup — never stale.
+ * - Hot Q&A pairs are purged on any write (the write may contradict them).
+ * - Everything expires after HOT_MEMORY_TTL (default 1h).
+ */
+
+interface HotQA {
+  question: string;
+  answer: string;
+  at: number;
+}
+
+const MAX_CONCEPTS = 10;
+const MAX_QAS = 10;
+const DEFAULT_TTL_MS = 3_600_000;
+const MAX_EXCERPT_CHARS = 1500;
+
+// Module-level: survives per-request McpServer instances (stateless HTTP).
+const hotConcepts = new Map<string, number>(); // path → touchedAt
+let hotQAs: HotQA[] = [];
+
+/** Called by the write tools after any concept write/patch. */
+export function recordHotWrite(path: string): void {
+  hotConcepts.delete(path);
+  hotConcepts.set(path, Date.now());
+  while (hotConcepts.size > MAX_CONCEPTS) {
+    const oldest = hotConcepts.keys().next().value;
+    if (oldest === undefined) break;
+    hotConcepts.delete(oldest);
+  }
+  // A write may contradict previous answers — drop them.
+  hotQAs = [];
+}
+
+/** Called on deletes: the concept leaves the hot set; answers may be stale. */
+export function recordHotDelete(path: string): void {
+  hotConcepts.delete(path);
+  hotQAs = [];
+}
+
+/** Called after a deep query completes. */
+export function recordHotQuery(question: string, answer: string): void {
+  hotQAs.push({ question, answer, at: Date.now() });
+  if (hotQAs.length > MAX_QAS) hotQAs = hotQAs.slice(-MAX_QAS);
+}
+
+/** Test hook. */
+export function clearHotMemory(): void {
+  hotConcepts.clear();
+  hotQAs = [];
+}
+
+export type HotGenerate = (
+  system: string,
+  prompt: string,
+  options: AgentOptions
+) => Promise<string>;
+
+/**
+ * Try to answer from the hot set. Returns the answer, or null when hot
+ * memory is empty/expired/disabled or can't answer confidently (the model
+ * must reply UNKNOWN in that case, which falls through to deep memory).
+ */
+export async function hotLookup(
+  kb: KnowledgeBase,
+  question: string,
+  options: AgentOptions = {},
+  // Injectable for tests.
+  generate: HotGenerate = defaultGenerate
+): Promise<string | null> {
+  if (process.env.HOT_MEMORY === "false") return null;
+  const ttl = parseDuration(process.env.HOT_MEMORY_TTL) ?? DEFAULT_TTL_MS;
+  const cutoff = Date.now() - ttl;
+
+  const sections: string[] = [];
+
+  for (const [path, touchedAt] of hotConcepts) {
+    if (touchedAt < cutoff) continue;
+    try {
+      const c = await kb.readConcept(path); // fresh read — never stale
+      const fm = c.frontmatter;
+      sections.push(
+        `CONCEPT ${c.path}${fm.title ? ` — ${fm.title}` : ""}${fm.description ? ` (${fm.description})` : ""}\n` +
+          c.body.slice(0, MAX_EXCERPT_CHARS)
+      );
+    } catch {
+      hotConcepts.delete(path); // deleted behind our back
+    }
+  }
+  for (const qa of hotQAs) {
+    if (qa.at < cutoff) continue;
+    sections.push(`PREVIOUS Q&A\nQ: ${qa.question}\nA: ${qa.answer}`);
+  }
+
+  if (sections.length === 0) return null;
+
+  const system =
+    `You answer questions using ONLY the recent-memory excerpts provided. ` +
+    `These are the most recently touched pieces of a larger knowledge base. ` +
+    `If they fully and confidently answer the question, answer concisely (and ` +
+    `cite concept paths when you used them). If they do NOT contain enough to ` +
+    `answer confidently, reply with exactly: UNKNOWN`;
+  const prompt = `RECENT MEMORY:\n\n${sections.join("\n\n---\n\n")}\n\nQUESTION: ${question}`;
+
+  const text = (await generate(system, prompt, options)).trim();
+  if (!text || /^UNKNOWN\b/i.test(text)) return null;
+  return text;
+}
+
+/**
+ * One tool-free generation. Provider access is feature-detected so this file
+ * works with both the current provider API (resolveModel) and the upcoming
+ * generic-slots API (resolveModelConfig/createModel) without edits.
+ */
+const defaultGenerate: HotGenerate = async (system, prompt, options) => {
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  const providers: any = await import("../providers/index.js");
+  let model;
+  if (typeof providers.resolveModel === "function") {
+    model = await providers.resolveModel((options as any).provider, options.model);
+  } else {
+    const cfg = providers.resolveModelConfig(process.env);
+    model = await providers.createModel(options.model ? { ...cfg, model: options.model } : cfg);
+  }
+  const { generateText } = await import("ai");
+  const result = await generateText({ model, system, prompt, temperature: 0 });
+  return result.text;
+};

--- a/packages/core/src/agent/query-cache.ts
+++ b/packages/core/src/agent/query-cache.ts
@@ -3,10 +3,13 @@ import { promises as fs } from "node:fs";
 import type { KnowledgeBase } from "../okf/index.js";
 import { parseDuration } from "../util/duration.js";
 import { runQuery, type AgentOptions, type QueryResult } from "./agent.js";
+import { hotLookup, recordHotQuery, type HotGenerate } from "./hot-memory.js";
 
 export interface CachedQueryResult extends QueryResult {
-  /** True when the answer came from the cache (no agent run, no trace). */
+  /** True when the answer came from the exact cache (no agent run, no trace). */
   cached: boolean;
+  /** Which memory layer answered: exact cache, hot working set, or the deep agent. */
+  source: "cache" | "hot" | "deep";
 }
 
 const MAX_ENTRIES = 200;
@@ -53,10 +56,11 @@ export async function runQueryCached(
   question: string,
   options: AgentOptions = {},
   // Injectable for tests.
-  runner: typeof runQuery = runQuery
+  runner: typeof runQuery = runQuery,
+  hot: (kb: KnowledgeBase, q: string, o: AgentOptions, g?: HotGenerate) => Promise<string | null> = hotLookup
 ): Promise<CachedQueryResult> {
   if (process.env.QUERY_CACHE === "false") {
-    return { ...(await runner(kb, question, options)), cached: false };
+    return { ...(await runner(kb, question, options)), cached: false, source: "deep" };
   }
 
   const fingerprint = await bundleFingerprint(kb);
@@ -64,23 +68,41 @@ export async function runQueryCached(
     .update(`${fingerprint}\n${normalize(question)}\n${options.model ?? ""}`)
     .digest("hex");
 
+  // Layer 1: exact cache — same question, unchanged bundle.
   const hit = cache.get(key);
   if (hit && hit.expiresAt > Date.now()) {
     // Refresh recency (Map preserves insertion order — delete + set = LRU touch).
     cache.delete(key);
     cache.set(key, hit);
-    return { ...hit.result, cached: true };
+    return { ...hit.result, cached: true, source: "cache" };
   }
 
-  const result = await runner(kb, question, options);
   const ttl = parseDuration(process.env.QUERY_CACHE_TTL) ?? DEFAULT_TTL_MS;
+
+  // Layer 2: hot working set — recently written concepts + recent answers,
+  // one tool-free LLM call. A confident hot answer also lands in the exact
+  // cache so identical repeats become instant.
+  const hotAnswer = await hot(kb, question, options);
+  if (hotAnswer !== null) {
+    const result: QueryResult = { answer: hotAnswer, steps: 0, traceId: "" };
+    store(key, result, ttl);
+    return { ...result, cached: false, source: "hot" };
+  }
+
+  // Layer 3: deep memory — the full agent loop. Its answer feeds the hot set.
+  const result = await runner(kb, question, options);
+  store(key, result, ttl);
+  recordHotQuery(question, result.answer);
+  return { ...result, cached: false, source: "deep" };
+}
+
+function store(key: string, result: QueryResult, ttl: number): void {
   cache.set(key, { expiresAt: Date.now() + ttl, result });
   while (cache.size > MAX_ENTRIES) {
     const oldest = cache.keys().next().value;
     if (oldest === undefined) break;
     cache.delete(oldest);
   }
-  return { ...result, cached: false };
 }
 
 /** Test hook: reset module-level cache state. */

--- a/packages/core/src/agent/query-cache.ts
+++ b/packages/core/src/agent/query-cache.ts
@@ -1,0 +1,93 @@
+import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
+import type { KnowledgeBase } from "../okf/index.js";
+import { parseDuration } from "../util/duration.js";
+import { runQuery, type AgentOptions, type QueryResult } from "./agent.js";
+
+export interface CachedQueryResult extends QueryResult {
+  /** True when the answer came from the cache (no agent run, no trace). */
+  cached: boolean;
+}
+
+const MAX_ENTRIES = 200;
+const DEFAULT_TTL_MS = 24 * 3_600_000;
+
+interface CacheEntry {
+  expiresAt: number;
+  result: QueryResult;
+}
+
+// Module-level so the cache survives the per-request McpServer instances of
+// the stateless HTTP transport.
+const cache = new Map<string, CacheEntry>();
+
+/**
+ * Content fingerprint of the bundle: path + mtime + size of every concept
+ * file. Any write moves the fingerprint, which implicitly invalidates every
+ * cached answer — no hooks into the write path needed.
+ */
+export async function bundleFingerprint(kb: KnowledgeBase): Promise<string> {
+  const paths = await kb.bundle.listConceptPaths();
+  const parts = await Promise.all(
+    paths.map(async (p) => {
+      try {
+        const st = await fs.stat(kb.bundle.resolve(p));
+        return `${p}:${st.mtimeMs}:${st.size}`;
+      } catch {
+        return `${p}:gone`;
+      }
+    })
+  );
+  return createHash("sha256").update(parts.join("|")).digest("hex");
+}
+
+/**
+ * runQuery with a fingerprint-invalidated LRU cache (issue-adjacent: repeated
+ * questions are common through MCP, and local models make every agent run
+ * expensive). Disabled with QUERY_CACHE=false; TTL via QUERY_CACHE_TTL
+ * (e.g. "1h", default 24h). Cache hits skip the agent entirely, so they
+ * record no trace.
+ */
+export async function runQueryCached(
+  kb: KnowledgeBase,
+  question: string,
+  options: AgentOptions = {},
+  // Injectable for tests.
+  runner: typeof runQuery = runQuery
+): Promise<CachedQueryResult> {
+  if (process.env.QUERY_CACHE === "false") {
+    return { ...(await runner(kb, question, options)), cached: false };
+  }
+
+  const fingerprint = await bundleFingerprint(kb);
+  const key = createHash("sha256")
+    .update(`${fingerprint}\n${normalize(question)}\n${options.model ?? ""}`)
+    .digest("hex");
+
+  const hit = cache.get(key);
+  if (hit && hit.expiresAt > Date.now()) {
+    // Refresh recency (Map preserves insertion order — delete + set = LRU touch).
+    cache.delete(key);
+    cache.set(key, hit);
+    return { ...hit.result, cached: true };
+  }
+
+  const result = await runner(kb, question, options);
+  const ttl = parseDuration(process.env.QUERY_CACHE_TTL) ?? DEFAULT_TTL_MS;
+  cache.set(key, { expiresAt: Date.now() + ttl, result });
+  while (cache.size > MAX_ENTRIES) {
+    const oldest = cache.keys().next().value;
+    if (oldest === undefined) break;
+    cache.delete(oldest);
+  }
+  return { ...result, cached: false };
+}
+
+/** Test hook: reset module-level cache state. */
+export function clearQueryCache(): void {
+  cache.clear();
+}
+
+function normalize(question: string): string {
+  return question.trim().toLowerCase().replace(/\s+/g, " ");
+}

--- a/packages/core/src/agent/tools.ts
+++ b/packages/core/src/agent/tools.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { KnowledgeBase } from "../okf/index.js";
 import type { TreeNode } from "../okf/types.js";
 import type { TraceRecorder } from "./trace.js";
+import { recordHotDelete, recordHotWrite } from "./hot-memory.js";
 
 /** Bundle-relative concept path, e.g. "/tables/customers.md". */
 const conceptPath = z
@@ -95,6 +96,7 @@ export function buildWriteTools(kb: KnowledgeBase, filesChanged: Set<string>, tr
       execute: async ({ path, frontmatter, body, log_summary }) => {
         const c = await kb.writeConcept(path, frontmatter, body, log_summary);
         filesChanged.add(c.path);
+        recordHotWrite(c.path);
         trace?.record("write_concept", c.path, [c.path], true);
         return { written: c.path };
       },
@@ -136,6 +138,7 @@ export function buildWriteTools(kb: KnowledgeBase, filesChanged: Set<string>, tr
           log_summary
         );
         filesChanged.add(c.path);
+        recordHotWrite(c.path);
         trace?.record("patch_concept", c.path, [c.path], true);
         return { patched: c.path };
       },
@@ -150,6 +153,7 @@ export function buildWriteTools(kb: KnowledgeBase, filesChanged: Set<string>, tr
       execute: async ({ path, log_summary }) => {
         await kb.deleteConcept(path, log_summary);
         filesChanged.add(path);
+        recordHotDelete(path);
         trace?.record("delete_concept", path, [path], true);
         return { deleted: path };
       },

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./okf/index.js";
 export * from "./agent/index.js";
 export * from "./agent/query-cache.js";
+export * from "./agent/hot-memory.js";
 export * from "./providers/index.js";
 export * from "./util/duration.js";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,3 +1,5 @@
 export * from "./okf/index.js";
 export * from "./agent/index.js";
+export * from "./agent/query-cache.js";
 export * from "./providers/index.js";
+export * from "./util/duration.js";

--- a/packages/core/src/util/duration.ts
+++ b/packages/core/src/util/duration.ts
@@ -1,0 +1,10 @@
+/** Parse "30s" | "15m" | "6h" | "1d" into milliseconds. Returns null for unset/invalid. */
+export function parseDuration(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const match = raw.trim().match(/^(\d+(?:\.\d+)?)\s*(ms|s|m|h|d)$/i);
+  if (!match) return null;
+  const value = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  const factor = { ms: 1, s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 }[unit]!;
+  return Math.round(value * factor);
+}

--- a/packages/core/test/hot-memory.test.ts
+++ b/packages/core/test/hot-memory.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { KnowledgeBase } from "../src/okf/index.js";
+import {
+  clearHotMemory,
+  hotLookup,
+  recordHotDelete,
+  recordHotQuery,
+  recordHotWrite,
+} from "../src/agent/hot-memory.js";
+import { clearQueryCache, runQueryCached } from "../src/agent/query-cache.js";
+import type { QueryResult } from "../src/agent/agent.js";
+
+let root: string;
+let kb: KnowledgeBase;
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "ustory-hot-"));
+  kb = new KnowledgeBase(root);
+  clearHotMemory();
+  clearQueryCache();
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+  delete process.env.HOT_MEMORY;
+  delete process.env.HOT_MEMORY_TTL;
+});
+
+describe("hotLookup", () => {
+  it("returns null without calling the model when the hot set is empty", async () => {
+    const generate = vi.fn();
+    expect(await hotLookup(kb, "anything?", {}, generate)).toBeNull();
+    expect(generate).not.toHaveBeenCalled();
+  });
+
+  it("answers from recently written concepts (read fresh) and falls through on UNKNOWN", async () => {
+    await kb.writeConcept("/facts/deploy.md", { type: "Fact", title: "Deploy day" }, "We deploy on Fridays.", "add");
+    recordHotWrite("/facts/deploy.md");
+
+    const confident = vi.fn(async () => "We deploy on Fridays. (from /facts/deploy.md)");
+    const answer = await hotLookup(kb, "when do we deploy?", {}, confident);
+    expect(answer).toContain("Fridays");
+    const prompt = confident.mock.calls[0][1] as string;
+    expect(prompt).toContain("/facts/deploy.md");
+    expect(prompt).toContain("We deploy on Fridays.");
+
+    const unsure = vi.fn(async () => "UNKNOWN");
+    expect(await hotLookup(kb, "what is the capital of France?", {}, unsure)).toBeNull();
+  });
+
+  it("purges hot Q&As on writes and drops deleted concepts", async () => {
+    recordHotQuery("q1", "a1");
+    recordHotWrite("/facts/x.md"); // any write invalidates prior answers
+    const generate = vi.fn(async () => "should not matter");
+    // /facts/x.md doesn't exist on disk → dropped at read; Q&As purged → empty set → null.
+    expect(await hotLookup(kb, "q1", {}, generate)).toBeNull();
+    expect(generate).not.toHaveBeenCalled();
+
+    recordHotDelete("/facts/x.md");
+    expect(await hotLookup(kb, "q1", {}, generate)).toBeNull();
+  });
+
+  it("expires entries after HOT_MEMORY_TTL and respects HOT_MEMORY=false", async () => {
+    vi.useFakeTimers();
+    try {
+      process.env.HOT_MEMORY_TTL = "1m";
+      await kb.writeConcept("/facts/a.md", { type: "Fact", title: "A" }, "alpha", "add");
+      recordHotWrite("/facts/a.md");
+      vi.advanceTimersByTime(61_000);
+      const generate = vi.fn();
+      expect(await hotLookup(kb, "a?", {}, generate)).toBeNull();
+      expect(generate).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+
+    process.env.HOT_MEMORY = "false";
+    await kb.writeConcept("/facts/b.md", { type: "Fact", title: "B" }, "beta", "add");
+    recordHotWrite("/facts/b.md");
+    const generate = vi.fn();
+    expect(await hotLookup(kb, "b?", {}, generate)).toBeNull();
+    expect(generate).not.toHaveBeenCalled();
+  });
+});
+
+describe("runQueryCached layering", () => {
+  it("hot answers short-circuit the deep agent and land in the exact cache", async () => {
+    const deep = vi.fn(async (): Promise<QueryResult> => ({ answer: "deep", steps: 5, traceId: "t" }));
+    const hot = vi.fn(async () => "hot answer");
+
+    const first = await runQueryCached(kb, "q?", {}, deep, hot);
+    expect(first.source).toBe("hot");
+    expect(first.answer).toBe("hot answer");
+    expect(deep).not.toHaveBeenCalled();
+
+    // Identical repeat: exact cache now answers, hot not consulted again.
+    const second = await runQueryCached(kb, "q?", {}, deep, hot);
+    expect(second.source).toBe("cache");
+    expect(hot).toHaveBeenCalledTimes(1);
+  });
+
+  it("deep answers feed the hot working set", async () => {
+    const deep = vi.fn(async (): Promise<QueryResult> => ({ answer: "42", steps: 3, traceId: "t" }));
+    await runQueryCached(kb, "meaning of life?", {}, deep, async () => null);
+
+    // The recorded Q&A is now available to a real hot lookup.
+    const generate = vi.fn(async () => "42 (from previous answer)");
+    const answer = await hotLookup(kb, "what was the meaning of life again?", {}, generate);
+    expect(answer).toContain("42");
+    const prompt = generate.mock.calls[0][1] as string;
+    expect(prompt).toContain("meaning of life?");
+  });
+});

--- a/packages/core/test/query-cache.test.ts
+++ b/packages/core/test/query-cache.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { KnowledgeBase } from "../src/okf/index.js";
 import { bundleFingerprint, clearQueryCache, runQueryCached } from "../src/agent/query-cache.js";
+import { clearHotMemory } from "../src/agent/hot-memory.js";
 import { parseDuration } from "../src/util/duration.js";
 import type { QueryResult } from "../src/agent/agent.js";
 
@@ -20,6 +21,8 @@ beforeEach(async () => {
   root = await fs.mkdtemp(path.join(os.tmpdir(), "ustory-cache-"));
   kb = new KnowledgeBase(root);
   clearQueryCache();
+  clearHotMemory();
+  process.env.HOT_MEMORY = "false";
   await kb.writeConcept("/facts/a.md", { type: "Fact", title: "A" }, "alpha", "add");
 });
 
@@ -27,6 +30,7 @@ afterEach(async () => {
   await fs.rm(root, { recursive: true, force: true });
   delete process.env.QUERY_CACHE;
   delete process.env.QUERY_CACHE_TTL;
+  delete process.env.HOT_MEMORY;
 });
 
 describe("runQueryCached", () => {

--- a/packages/core/test/query-cache.test.ts
+++ b/packages/core/test/query-cache.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { KnowledgeBase } from "../src/okf/index.js";
+import { bundleFingerprint, clearQueryCache, runQueryCached } from "../src/agent/query-cache.js";
+import { parseDuration } from "../src/util/duration.js";
+import type { QueryResult } from "../src/agent/agent.js";
+
+let root: string;
+let kb: KnowledgeBase;
+
+function fakeRunner(answer: string) {
+  return vi.fn(
+    async (): Promise<QueryResult> => ({ answer, steps: 1, traceId: "t" })
+  );
+}
+
+beforeEach(async () => {
+  root = await fs.mkdtemp(path.join(os.tmpdir(), "ustory-cache-"));
+  kb = new KnowledgeBase(root);
+  clearQueryCache();
+  await kb.writeConcept("/facts/a.md", { type: "Fact", title: "A" }, "alpha", "add");
+});
+
+afterEach(async () => {
+  await fs.rm(root, { recursive: true, force: true });
+  delete process.env.QUERY_CACHE;
+  delete process.env.QUERY_CACHE_TTL;
+});
+
+describe("runQueryCached", () => {
+  it("serves repeats from cache without re-running the agent", async () => {
+    const runner = fakeRunner("answer-1");
+    const first = await runQueryCached(kb, "what is A?", {}, runner);
+    const second = await runQueryCached(kb, "  What is  A? ", {}, runner); // normalized match
+    expect(first.cached).toBe(false);
+    expect(second.cached).toBe(true);
+    expect(second.answer).toBe("answer-1");
+    expect(runner).toHaveBeenCalledTimes(1);
+  });
+
+  it("invalidates when the bundle changes", async () => {
+    const runner = fakeRunner("answer");
+    await runQueryCached(kb, "what is A?", {}, runner);
+    await kb.writeConcept("/facts/b.md", { type: "Fact", title: "B" }, "beta — longer content", "add");
+    const after = await runQueryCached(kb, "what is A?", {}, runner);
+    expect(after.cached).toBe(false);
+    expect(runner).toHaveBeenCalledTimes(2);
+  });
+
+  it("misses on a different question and respects QUERY_CACHE=false", async () => {
+    const runner = fakeRunner("answer");
+    await runQueryCached(kb, "q1", {}, runner);
+    await runQueryCached(kb, "q2", {}, runner);
+    expect(runner).toHaveBeenCalledTimes(2);
+
+    process.env.QUERY_CACHE = "false";
+    await runQueryCached(kb, "q1", {}, runner);
+    expect(runner).toHaveBeenCalledTimes(3);
+  });
+
+  it("expires entries after the TTL", async () => {
+    vi.useFakeTimers();
+    try {
+      process.env.QUERY_CACHE_TTL = "1m";
+      const runner = fakeRunner("answer");
+      await runQueryCached(kb, "q", {}, runner);
+      vi.advanceTimersByTime(61_000);
+      const after = await runQueryCached(kb, "q", {}, runner);
+      expect(after.cached).toBe(false);
+      expect(runner).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("bundleFingerprint", () => {
+  it("is stable for an unchanged bundle and moves on writes", async () => {
+    const f1 = await bundleFingerprint(kb);
+    const f2 = await bundleFingerprint(kb);
+    expect(f1).toBe(f2);
+    await kb.writeConcept("/facts/c.md", { type: "Fact", title: "C" }, "gamma", "add");
+    expect(await bundleFingerprint(kb)).not.toBe(f1);
+  });
+});
+
+describe("parseDuration", () => {
+  it("parses common forms and rejects junk", () => {
+    expect(parseDuration("30s")).toBe(30_000);
+    expect(parseDuration("15m")).toBe(900_000);
+    expect(parseDuration("6h")).toBe(21_600_000);
+    expect(parseDuration("1d")).toBe(86_400_000);
+    expect(parseDuration(undefined)).toBeNull();
+    expect(parseDuration("soon")).toBeNull();
+  });
+});

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -41,9 +41,10 @@ export async function buildMcpServer(kb: KnowledgeBase): Promise<McpServer> {
       inputSchema: { question: z.string().describe("The question to answer") },
     },
     async ({ question }) => {
-      const { answer, cached } = await runQueryCached(kb, question);
+      const { answer, source } = await runQueryCached(kb, question);
+      const marker = source === "cache" ? "\n\n(cached answer)" : source === "hot" ? "\n\n(hot memory)" : "";
       return {
-        content: [{ type: "text", text: cached ? `${answer}\n\n(cached answer)` : answer }],
+        content: [{ type: "text", text: `${answer}${marker}` }],
       };
     }
   );

--- a/packages/server/src/mcp/server.ts
+++ b/packages/server/src/mcp/server.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { z } from "zod";
 import { KnowledgeBase, runQuery, runMutation } from "@understory/core";
+import { runQueryCached } from "@understory/core";
 import { buildSeedMemory, seedInstructions } from "./seed.js";
 
 /**
@@ -40,8 +41,10 @@ export async function buildMcpServer(kb: KnowledgeBase): Promise<McpServer> {
       inputSchema: { question: z.string().describe("The question to answer") },
     },
     async ({ question }) => {
-      const { answer } = await runQuery(kb, question);
-      return { content: [{ type: "text", text: answer }] };
+      const { answer, cached } = await runQueryCached(kb, question);
+      return {
+        content: [{ type: "text", text: cached ? `${answer}\n\n(cached answer)` : answer }],
+      };
     }
   );
 


### PR DESCRIPTION
Layered retrieval for `memory_query`: **exact cache → hot working set → deep agent.**

**Layer 1 — exact cache.** Cache key = sha256(bundle fingerprint + normalized question + model override). The fingerprint is path+mtime+size of every concept file, so any write invalidates everything without hooks in the write path. LRU, 200 entries, 24h TTL (`QUERY_CACHE_TTL`), `QUERY_CACHE=false` to disable. Hits are marked `(cached answer)`.

**Layer 2 — hot memory.** Recently written concepts (last 10, stored as paths and read fresh at lookup, so never stale) plus recent deep answers (last 10 Q&As) form a working set. A query that misses the exact cache makes ONE tool-free LLM call over this small context; a confident answer returns immediately (marked `(hot memory)`) and also lands in the exact cache. The model answers `UNKNOWN` → fall through. Writes purge hot Q&As (they may be contradicted) while adding the written concept. `HOT_MEMORY=false` / `HOT_MEMORY_TTL` (default 1h).

**Layer 3 — deep memory.** The full agent loop, unchanged. Its answers feed the hot set.

Verified live against llama.cpp: `memory_add` a fact → a *differently phrased* question answered from `(hot memory)` with the concept path cited, no agent loop → an exact repeat answered from `(cached answer)` in 0s.

12 new tests (34 total) across cache layering, hot lookup, invalidation, TTLs, and the disable flags.
