### PR TITLE
Fix duplicate sections appearing when patching concepts via agent

### DIFF
--- a/packages/core/src/okf/bundle.ts
+++ b/packages/core/src/okf/bundle.ts
@@ -250,9 +250,9 @@ export class Bundle {
 export function replaceSection(body: string, heading: string, content: string): string {
   const normalized = heading.replace(/^#+\s*/, "");
   const lines = body.split("\n");
-  const isHeading = (line: string) => /^#\s+/.test(line);
+  const isHeading = (line: string) => /^#+\s/.test(line);
   const start = lines.findIndex(
-    (line) => isHeading(line) && line.replace(/^#\s+/, "").trim() === normalized
+    (line) => isHeading(line) && line.replace(/^#+\s/, "").trim() === normalized
   );
   if (start === -1) {
     const suffix = body.trim().length > 0 ? "\n\n" : "";

--- a/packages/core/test/okf.test.ts
+++ b/packages/core/test/okf.test.ts
@@ -142,6 +142,19 @@ describe("patch", () => {
     expect(patched.body).toContain("intro text");
   });
 
+  it("replaces a ## (H2) subsection without duplicating", () => {
+    const body = "# Journal\n\nintro\n\n## Life\n\nold entry\n\n## Dev\n\nkeep me";
+    const out = replaceSection(body, "Life", "new entry");
+    expect(out).toContain("## Life");
+    expect(out).toContain("new entry");
+    expect(out).not.toContain("old entry");
+    expect(out).toContain("keep me");
+    expect(out).toContain("# Journal");
+    expect(out).toContain("intro");
+    // Must not append a duplicate H1 section
+    expect(out).not.toMatch(/^# Life$/m);
+  });
+
   it("appends the section when the heading is absent", () => {
     const out = replaceSection("just a body", "Citations", "[1] [X](https://x.com)");
     expect(out).toContain("# Citations");


### PR DESCRIPTION
When the knowledge-base agent updates an existing concept via patch_concept, sections using ## H2 headings in the concepts can't be found by the replacement logic. The function goes to append and writes a duplicate section at the bottom of the file instead of replacing the original.

H2 is a common thing to use, so it's a problem. The isHeading regex + normalization in replaceSection only matched # H1 headings. H2+ headings were invisible to it.

So, here's a fixed regexp so it catches any headings leve + a test