### PR TITLE
feat: always include name/titel in seed's concept description

### DIFF
--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,7 +11,8 @@
     "dev": "tsx watch src/index.ts",
     "start": "node dist/index.js",
     "mcp:stdio": "tsx src/mcp/stdio.ts",
-    "test": "vitest run --passWithNoTests"
+    "test": "pnpm run typecheck:test && vitest run --passWithNoTests",
+    "typecheck:test": "tsc -p tsconfig.test.json"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",

--- a/packages/server/src/mcp/seed.ts
+++ b/packages/server/src/mcp/seed.ts
@@ -77,10 +77,17 @@ function collectConcepts(node: TreeNode): {
     } else if (child.kind === "concept") {
       out.count++;
       if (child.type) out.types.add(child.type);
-      out.descriptions.push(child.description ?? child.title ?? child.name);
+      out.descriptions.push(deriveConceptDescription(child));
     }
   }
   return out;
+}
+
+/** Derives a concept description always containing either name or title from a tree node representing a concept */
+export function deriveConceptDescription(node: TreeNode): string {
+  const subject: string = `**${node.title ?? node.name}**`;
+
+  return node.description ? `${subject}, ${node.description}` : subject;
 }
 
 /** The initialize `instructions` block — seed plus the instinct-igniting rules. */

--- a/packages/server/test/mcp/seed.test.ts
+++ b/packages/server/test/mcp/seed.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+import type { TreeNode } from "@understory/core";
+import { deriveConceptDescription } from "../../src/mcp/seed.js";
+
+describe("seed", () => {
+  describe("deriveConceptDescription", () => {
+    const name = "foo";
+    const title = "Foo";
+    const description =
+      "a main-belt asteroid that was discovered on September 2nd, 1983, by the Belgian astronomer Henri Debehogne";
+
+    const cases: Record<string, { input: Pick<TreeNode, 'name'> & Partial<Pick<TreeNode, 'title' | 'description'>>; expected: string }> = {
+      "name only": {
+        input: { name },
+        expected: `**${name}**`,
+      },
+      "name and title": {
+        input: { name, title },
+        expected: `**${title}**`,
+      },
+      "name and description": {
+        input: { name, description },
+        expected: `**${name}**, ${description}`,
+      },
+      "name and title and description": {
+        input: { name, title, description },
+        expected: `**${title}**, ${description}`,
+      },
+    };
+
+    Object.entries(cases).forEach(([test_desc, test_case]) => {
+      it(`provides a suitable description for concept tree nodes containing ${test_desc}`, () => {
+        const { input, expected } = test_case;
+
+        const actual = deriveConceptDescription(input as TreeNode);
+
+        expect(actual).toEqual(expected);
+      });
+    });
+  });
+});

--- a/packages/server/tsconfig.test.json
+++ b/packages/server/tsconfig.test.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "rootDir": "."
+  },
+  "include": ["src", "test"]
+}


### PR DESCRIPTION
## Issue

When working with my bundle, I discovered that the concept descriptions in the seed used in the `memory_query` tool's description do not contain the name or title (read: subject) of a concept if said concept has a description. In this case only the description is used. 

At least during my tests with Qwen 36B-A3B, the descriptions were elaborations on the name/title of a concept resulting in a seed **without** the actual subject of a concept. 

As an example, consider the following:

* name "foo"
* title "(4334) Foo"
* description: "Main-belt asteroid discovered by Henri Debehogne on September 2nd, 1983,"

would result in a concept list entry in the seed that never actually mentions the subject "Foo" itself. An LLM can therefore never pick up the subject and query the memory for additional information. Naturally, the same problem applies to the instruction block since the seed is used there similarly.

If you share my opinion on that matter I'd very much appreciate you accepting the pull request.

## Proposed Solution

When building a description for concepts for the seed, always include either title or name in this order and append the description in case a concept has such. 

Using the example from above, the resulting `memory_query` tool's description containing the seed is as follows.

**Before:**
```
Ask a natural-language question. An internal agent searches the OKF knowledge base, reads relevant concepts, and answers with cited bundle paths.

CURRENT MEMORY OVERVIEW:
Concept types in use: Asteroid

Memory segments:
* asteroids/ — 1 concept (Asteroid):
    * Main-belt asteroid discovered by Henri Debehogne on September 2nd, 1983.

Recent activity:
- 2026-07-23 Creation: Added [(4334) Foo](/asteroids/foo.md), a main-belt asteroid discovered by Henri Debehogne at La Silla Observatory on September 2nd, 1983.
```

**After:**
```
Ask a natural-language question. An internal agent searches the OKF knowledge base, reads relevant concepts, and answers with cited bundle paths.

CURRENT MEMORY OVERVIEW:
Concept types in use: Asteroid

Memory segments:
* asteroids/ — 1 concept (Asteroid):
    * **(4334) Foo**, Main-belt asteroid discovered by Henri Debehogne on September 2nd, 1983.

Recent activity:
- 2026-07-23 Creation: Added [(4334) Foo](/asteroids/foo.md), a main-belt asteroid discovered by Henri Debehogne at La Silla Observatory on September 2nd, 1983.
```

## Change Summary

I directly tapped into the server's `mcp/seed.ts` and introduced a new function returning a concept description from a tree node. The changes are minimal. I set up tests to check for all possible combinations and to demonstrate the effect.