### PR TITLE
feat: serve the web UI from behind a sub-path reverse proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,24 @@ claude mcp add --transport http ustory http://host:3800/mcp \
 
 The stdio transport needs no token — it's a local process spawned by the client.
 
+### Serving under a sub-path
+
+The web UI uses relative URLs throughout, so it works behind a path-prefixing reverse proxy — no configuration needed. Any proxy that strips the prefix before forwarding works:
+
+```bash
+# Tailscale
+tailscale serve --bg --set-path=/understory http://localhost:3800
+```
+
+```caddy
+# Caddy
+handle_path /understory/* {
+  reverse_proxy localhost:3800
+}
+```
+
+One rule: open the UI with a trailing slash (`https://host/understory/`, not `.../understory`) — relative URLs resolve against the last path segment, so without the slash they escape the prefix. If your proxy can redirect `/understory` → `/understory/`, do that.
+
 ### Seed memory
 
 A client LLM that only sees four bare tool names never gets the instinct to check memory. So at **session start** the server injects a compact overview of what the knowledge base contains (directories, concepts with types + descriptions, recent activity) through both channels that reach the model:

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -101,8 +101,18 @@ export class ApiError extends Error {
   }
 }
 
+/**
+ * Resolve an API path against the page URL so calls work when the UI is served
+ * behind a path-prefixing reverse proxy (e.g. https://host/understory/), where
+ * a root-absolute "/api/..." would escape the prefix. Matches how the page's
+ * relative asset URLs resolve.
+ */
+export function apiUrl(path: string): string {
+  return new URL(path.replace(/^\//, ""), document.baseURI).toString();
+}
+
 async function get<T>(url: string): Promise<T> {
-  const res = await fetch(url, { headers: authHeaders() });
+  const res = await fetch(apiUrl(url), { headers: authHeaders() });
   if (!res.ok) throw new ApiError(res.status, `${res.status} ${await res.text()}`);
   return res.json();
 }

--- a/packages/web/src/components/ChatPanel.tsx
+++ b/packages/web/src/components/ChatPanel.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { useChat } from "@ai-sdk/react";
 import { DefaultChatTransport } from "ai";
 import ReactMarkdown from "react-markdown";
-import { authHeaders } from "../api";
+import { apiUrl, authHeaders } from "../api";
 import type { AppConfig } from "../api";
 
 const WRITE_TOOLS = new Set(["write_concept", "patch_concept", "delete_concept"]);
@@ -24,7 +24,7 @@ export function ChatPanel({
   const [model, setModel] = useState("");
   const { messages, sendMessage, status } = useChat({
     transport: new DefaultChatTransport({
-      api: "/api/chat",
+      api: apiUrl("/api/chat"),
       headers: () => authHeaders(),
       body: () => ({ model: model || undefined }),
     }),

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -2,6 +2,10 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  // Relative asset URLs so the built UI also works behind a path-prefixing
+  // reverse proxy (e.g. https://host/understory/), not just at the site root.
+  // API calls resolve the same way — see apiUrl() in src/api.ts.
+  base: "./",
   plugins: [react()],
   server: {
     port: 5180,


### PR DESCRIPTION
## Problem

The built web UI only works at the site root. Behind a path-prefixing reverse proxy (e.g. `tailscale serve --set-path=/understory http://host:3800`, or a Caddy `handle_path` block) the page itself loads, but everything it references escapes the prefix and 404s:

- `index.html` asset tags are root-absolute (`/assets/index-*.js`) because Vite builds with the default `base`
- every frontend fetch hard-codes root-absolute paths (`/api/tree`, `/api/chat`, ...)

`/mcp` and `/api` clients are unaffected (they're configured with the full URL), so this bites exactly the people who proxy the MCP endpoint to a sub-path and then find the UI broken at the same address.

## Change

Make the UI location-independent instead of adding a BASE_PATH knob, so the same image works at the root and under any prefix with zero configuration:

- **`vite.config.ts`**: `base: "./"` - built asset URLs become relative. Safe here because the app has no client-side router; `index.html` is only ever served at the app's root.
- **`api.ts`**: new `apiUrl()` helper resolves API paths against `document.baseURI`, and the shared `get()` routes through it - so all nine REST calls (and any future ones) inherit the fix.
- **`ChatPanel.tsx`**: the chat transport is the one call site outside the helper; it now uses `apiUrl("/api/chat")`.
- **README**: short 'Serving under a sub-path' section with proxy examples and the one caveat: open the UI with a trailing slash (`/understory/`, not `/understory`), since relative URLs resolve against the last path segment. Proxies that can redirect the bare form should.

No server changes: a prefix-stripping proxy means Express never sees the prefix, and the SPA fallback regex is already path-agnostic.

## Verification

- `pnpm build` + `pnpm test` pass; built `index.html` now references `./assets/...`
- Headless Chrome against the built server behind a minimal prefix-stripping test proxy (mimicking `tailscale serve`): the tree renders a seeded concept, i.e. assets AND `/prefix/api/tree` both resolve through the prefix
- Same check directly at the site root: no regression
- Real-world motivation verified against a live deployment proxied at `https://<tailnet-host>/understory`