### PR TITLE
fix(docker): reach host llama.cpp via host.docker.internal

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ services:
     image: ghcr.io/thecodacus/understory:latest
     ports:
       - "3800:3800"
+    # Lets the container reach a llama.cpp server running on the host via
+    # http://host.docker.internal:8080/v1 (see "Local llama.cpp" below).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       # Your memory lives here as plain markdown — a named volume, or point
       # a bind mount (e.g. ./my-memory:/bundle) at any OKF bundle.
@@ -77,12 +81,17 @@ LLM_API_BASE_URL=https://api.groq.com/openai/v1 LLM_API_KEY=gsk_... LLM_MODEL=ll
 
 **Local llama.cpp:**
 ```bash
-LLM_API_BASE_URL=http://localhost:8080/v1 LLM_MODEL=
+LLM_API_BASE_URL=http://host.docker.internal:8080/v1 LLM_MODEL=
 ```
+
+> When understory runs in Docker, `localhost` is the container itself, not the
+> host — so a llama-server on the host is reached at `host.docker.internal`
+> (the compose files above already map it via `extra_hosts`). Running from
+> source on the same box as llama-server, use `http://localhost:8080/v1`.
 
 **Local llama.cpp with DeepSeek fallback:**
 ```bash
-LLM_API_BASE_URL=http://localhost:8080/v1 LLM_MODEL= \
+LLM_API_BASE_URL=http://host.docker.internal:8080/v1 LLM_MODEL= \
 LLM_FALLBACK_API_BASE_URL=https://api.deepseek.com/v1 LLM_FALLBACK_API_KEY=sk-... LLM_FALLBACK_MODEL=deepseek-chat
 ```
 

--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -6,6 +6,10 @@ services:
     image: ghcr.io/thecodacus/understory:latest
     ports:
       - "3800:3800"
+    # Lets the container reach a llama.cpp server running on the host via
+    # http://host.docker.internal:8080/v1 (see "Local llama.cpp" in the README).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       # Persistent OKF bundle. Swap for a bind mount (e.g. /srv/okf-bundle:/bundle)
       # if you want to edit the markdown from the host / sync it with git.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,10 @@ services:
     build: .
     ports:
       - "3800:3800"
+    # Lets the container reach a llama.cpp server running on the host via
+    # http://host.docker.internal:8080/v1 (see "Local llama.cpp" in the README).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     volumes:
       - ./sample-bundle:/bundle
     environment:


### PR DESCRIPTION
## Problem

The README documents a local llama.cpp setup:

```bash
LLM_API_BASE_URL=http://localhost:8080/v1 LLM_MODEL=
```

But the compose files use bridge networking, where `localhost` is the container itself — not the host. A llama-server running on the host is unreachable, so the documented local path fails silently (the agent can't reach the model).

## Fix

Add `extra_hosts: host.docker.internal:host-gateway` to both compose files, and point the README's local-llama.cpp examples at `http://host.docker.internal:8080/v1`. Running from source on the same box still uses `localhost`.

## Notes

- `host-gateway` is the portable Docker mechanism (works on Linux, macOS, Windows) — no `network_mode: host` needed, which would be Linux-only and would drop the port mapping.
- The llama-server itself must bind `0.0.0.0` (the README's llama.cpp example already shows `--host 0.0.0.0`), so the two halves are consistent.
- Verified: a container with `--add-host host.docker.internal:host-gateway` reaches a host service bound to `0.0.0.0`.