### PR TITLE
Build for arm64 as well as amd64

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,6 +34,9 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v4
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
       - uses: docker/setup-buildx-action@v3
       - uses: docker/login-action@v3
         with:
@@ -51,6 +54,7 @@ jobs:
       - uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
When you want to use Understory on a Mac, you'd prefer to have the container run in the default architecture rather than the translation layer.

This change makes sure that the build system builds the container for both ARM and x86 architectures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images are now published for both AMD64 and ARM64 platforms, improving compatibility across hardware architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->