### PR TITLE
Slim down the Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.bundle
+.git
+.github
+coverage
+node_modules
+packages/*/node_modules
+packages/*/dist
+packages/*/*.tsbuildinfo

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,20 +7,15 @@ COPY packages/server/package.json packages/server/
 COPY packages/web/package.json packages/web/
 RUN pnpm install --frozen-lockfile
 COPY packages packages
-RUN pnpm -r build && pnpm prune --prod
+RUN pnpm -r build
+RUN pnpm --filter @understory/server deploy --prod --legacy /deploy/server
 
-FROM node:22-alpine
+FROM node:22-alpine AS runtime
 WORKDIR /app
-COPY --from=build /app/node_modules node_modules
-COPY --from=build /app/packages/core/dist packages/core/dist
-COPY --from=build /app/packages/core/package.json packages/core/
-COPY --from=build /app/packages/core/node_modules packages/core/node_modules
-COPY --from=build /app/packages/server/dist packages/server/dist
-COPY --from=build /app/packages/server/package.json packages/server/
-COPY --from=build /app/packages/server/node_modules packages/server/node_modules
-COPY --from=build /app/packages/web/dist packages/web/dist
+COPY --from=build /deploy/server server
+COPY --from=build /app/packages/web/dist web/dist
 
-ENV BUNDLE_ROOT=/bundle PORT=3800
+ENV NODE_ENV=production BUNDLE_ROOT=/bundle PORT=3800
 EXPOSE 3800
 VOLUME /bundle
-CMD ["node", "packages/server/dist/index.js"]
+CMD ["node", "server/dist/index.js"]


### PR DESCRIPTION
This change uses pnpm's deploy-to-production filter to remove all of the files that are unnecessary for deployment. This saves a few hundred megabytes in size for the resulting Docker image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved Docker build exclusions to reduce unnecessary build context.
  * Updated the production container setup for a smaller, streamlined deployment.
  * Production deployments now run with optimized settings and start from the generated server bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->